### PR TITLE
Add structural-framing + ported Python MCP tools (KPFF parameter-driven)

### DIFF
--- a/revit_mcp/detail.py
+++ b/revit_mcp/detail.py
@@ -1,0 +1,153 @@
+# -*- coding: UTF-8 -*-
+"""
+Detail Module for Revit MCP
+Handles detail line creation for view-specific annotation
+"""
+
+from utils import get_element_name, get_element_id_value
+from pyrevit import routes, revit, DB
+import json
+import traceback
+import logging
+
+logger = logging.getLogger(__name__)
+
+MM_TO_FEET = 1.0 / 304.8
+
+
+def register_detail_routes(api):
+    """Register all detail routes with the API"""
+
+    @api.route("/create_detail_line/", methods=["POST"])
+    def create_detail_line_handler(doc, request):
+        """Create a detail line in a view."""
+        try:
+            if not doc:
+                return routes.make_response(
+                    data={"error": "No active Revit document"}, status=503
+                )
+
+            data = json.loads(request.data) if isinstance(request.data, str) else request.data
+
+            start_point = data.get("start_point")
+            end_point = data.get("end_point")
+            if not start_point or not end_point:
+                return routes.make_response(
+                    data={"error": "start_point and end_point are required"},
+                    status=400,
+                )
+
+            # Find the view
+            view_name = data.get("view_name")
+            target_view = None
+            if view_name:
+                views = (
+                    DB.FilteredElementCollector(doc)
+                    .OfClass(DB.View)
+                    .WhereElementIsNotElementType()
+                    .ToElements()
+                )
+                for v in views:
+                    if get_element_name(v) == view_name and not v.IsTemplate:
+                        target_view = v
+                        break
+                if not target_view:
+                    return routes.make_response(
+                        data={"error": "View '{}' not found".format(view_name)},
+                        status=404,
+                    )
+            else:
+                target_view = doc.ActiveView
+
+            # Check view type compatibility
+            try:
+                vt = target_view.ViewType
+                allowed_types = [
+                    DB.ViewType.FloorPlan, DB.ViewType.CeilingPlan,
+                    DB.ViewType.Section, DB.ViewType.Detail,
+                    DB.ViewType.Elevation, DB.ViewType.DraftingView,
+                    DB.ViewType.AreaPlan,
+                ]
+                if vt not in allowed_types:
+                    return routes.make_response(
+                        data={"error": "Cannot create detail line — the specified view is not a plan or detail view."},
+                        status=500,
+                    )
+            except Exception:
+                pass
+
+            start = DB.XYZ(
+                float(start_point.get("x", 0)) * MM_TO_FEET,
+                float(start_point.get("y", 0)) * MM_TO_FEET,
+                float(start_point.get("z", 0)) * MM_TO_FEET,
+            )
+            end = DB.XYZ(
+                float(end_point.get("x", 0)) * MM_TO_FEET,
+                float(end_point.get("y", 0)) * MM_TO_FEET,
+                float(end_point.get("z", 0)) * MM_TO_FEET,
+            )
+
+            line = DB.Line.CreateBound(start, end)
+
+            t = DB.Transaction(doc, "Create Detail Line via MCP")
+            t.Start()
+
+            try:
+                detail_curve = doc.Create.NewDetailCurve(target_view, line)
+
+                if not detail_curve:
+                    t.RollBack()
+                    return routes.make_response(
+                        data={"error": "Failed to create detail line"},
+                        status=500,
+                    )
+
+                # Set line style if specified
+                line_style = data.get("line_style")
+                if line_style:
+                    try:
+                        # Find the line style
+                        line_styles = detail_curve.GetLineStyleIds()
+                        cat = doc.Settings.Categories
+                        line_cat = None
+                        try:
+                            line_cat = cat.get_Item(DB.BuiltInCategory.OST_Lines)
+                        except Exception:
+                            pass
+
+                        if line_cat:
+                            for sub_cat in line_cat.SubCategories:
+                                if get_element_name(sub_cat) == line_style:
+                                    # Get the GraphicsStyle for this category
+                                    gs_id = sub_cat.GetGraphicsStyle(DB.GraphicsStyleType.Projection).Id
+                                    detail_curve.LineStyle = doc.GetElement(gs_id)
+                                    break
+                    except Exception as style_err:
+                        logger.debug("Could not set line style: {}".format(str(style_err)))
+
+                t.Commit()
+
+                actual_view_name = get_element_name(target_view)
+
+                return routes.make_response(
+                    data={
+                        "status": "success",
+                        "line_id": get_element_id_value(detail_curve),
+                        "view_name": actual_view_name,
+                        "message": "Created detail line in view '{}'".format(actual_view_name),
+                    }
+                )
+
+            except Exception as tx_error:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                raise tx_error
+
+        except Exception as e:
+            logger.error("Failed to create detail line: {}".format(str(e)))
+            error_trace = traceback.format_exc()
+            return routes.make_response(
+                data={"error": str(e), "traceback": error_trace}, status=500
+            )
+
+    logger.info("Detail routes registered successfully")

--- a/revit_mcp/detailing.py
+++ b/revit_mcp/detailing.py
@@ -1,0 +1,206 @@
+# -*- coding: UTF-8 -*-
+"""
+2D detailing routes: markups, detail/model/symbolic shapes (ported from
+Revit-2026-MCP-Server) + detail-component placement, filled regions, and
+masking regions (new). Units in FEET, angles in DEGREES.
+"""
+
+from utils import get_element_name, find_family_symbol_safely, element_id_value
+from pyrevit import routes, DB
+import json, math, traceback, logging
+
+logger = logging.getLogger(__name__)
+
+
+def _parse(request):
+    if not request or not request.data:
+        return {}
+    return json.loads(request.data) if isinstance(request.data, str) else request.data
+
+
+def _pt(d):
+    return DB.XYZ(float(d.get("x", 0)), float(d.get("y", 0)), float(d.get("z", 0)))
+
+
+def _view(doc, b):
+    if b.get("view_id"):
+        el = doc.GetElement(DB.ElementId(int(b["view_id"])))
+        if isinstance(el, DB.View):
+            return el
+    if b.get("view_name"):
+        for v in DB.FilteredElementCollector(doc).OfClass(DB.View):
+            if not v.IsTemplate and get_element_name(v) == b["view_name"]:
+                return v
+    return doc.ActiveView
+
+
+def _shape_points(shape, center, w, h, r, sides, rot_deg):
+    a = math.radians(rot_deg)
+    ca, sa = math.cos(a), math.sin(a)
+    cx, cy, cz = center.X, center.Y, center.Z
+    def rotxy(dx, dy):
+        return DB.XYZ(cx + dx * ca - dy * sa, cy + dx * sa + dy * ca, cz)
+    s = shape.lower()
+    if s == "rectangle":
+        hw, hh = w / 2.0, h / 2.0
+        return [rotxy(-hw, -hh), rotxy(hw, -hh), rotxy(hw, hh), rotxy(-hw, hh)]
+    if s == "circle":
+        n = 36
+        return [rotxy(r * math.cos(2 * math.pi * i / n), r * math.sin(2 * math.pi * i / n)) for i in range(n)]
+    # polygon
+    n = max(3, int(sides))
+    return [rotxy(r * math.cos(2 * math.pi * i / n), r * math.sin(2 * math.pi * i / n)) for i in range(n)]
+
+
+def _err(e):
+    return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+
+def register_detailing_routes(api):
+
+    @api.route("/create_point_markup/", methods=["POST"])
+    def create_point_markup(doc, request):
+        """Detail markups at points. Body: {points:[{x,y,z},...], markup_type:'cross|circle|square', size:1.0}"""
+        try:
+            b = _parse(request); view = doc.ActiveView
+            pts = b.get("points") or []
+            mt = (b.get("markup_type") or "cross").lower(); size = float(b.get("size", 1.0))
+            t = DB.Transaction(doc, "Point Markups"); t.Start(); made = []
+            for pd in pts:
+                c = _pt(pd)
+                if mt == "circle":
+                    for (a0, a1) in ((0, math.pi), (math.pi, 2 * math.pi)):
+                        arc = DB.Arc.Create(c, size, a0, a1, DB.XYZ.BasisX, DB.XYZ.BasisY)
+                        made.append(element_id_value(doc.Create.NewDetailCurve(view, arc).Id))
+                elif mt == "square":
+                    pts4 = [DB.XYZ(c.X - size, c.Y - size, c.Z), DB.XYZ(c.X + size, c.Y - size, c.Z),
+                            DB.XYZ(c.X + size, c.Y + size, c.Z), DB.XYZ(c.X - size, c.Y + size, c.Z)]
+                    for i in range(4):
+                        made.append(element_id_value(doc.Create.NewDetailCurve(view, DB.Line.CreateBound(pts4[i], pts4[(i + 1) % 4])).Id))
+                else:  # cross
+                    h = DB.Line.CreateBound(DB.XYZ(c.X - size, c.Y, c.Z), DB.XYZ(c.X + size, c.Y, c.Z))
+                    v = DB.Line.CreateBound(DB.XYZ(c.X, c.Y - size, c.Z), DB.XYZ(c.X, c.Y + size, c.Z))
+                    made.append(element_id_value(doc.Create.NewDetailCurve(view, h).Id))
+                    made.append(element_id_value(doc.Create.NewDetailCurve(view, v).Id))
+            t.Commit()
+            return routes.make_response(data={"status": "success", "markup_type": mt, "curve_ids": made})
+        except Exception as e: return _err(e)
+
+    def _shapes(doc, request, mode):
+        b = _parse(request)
+        shape = b["shape_type"]
+        center = DB.XYZ(float(b.get("center_x", 0)), float(b.get("center_y", 0)), float(b.get("center_z", 0)))
+        pts = _shape_points(shape, center, float(b.get("width", 5)), float(b.get("height", 5)),
+                            float(b.get("radius", 5)), int(b.get("sides", 6)), float(b.get("rotation", 0)))
+        view = _view(doc, b)
+        sp = None
+        if mode == "model":
+            sp = DB.SketchPlane.Create(doc, DB.Plane.CreateByNormalAndOrigin(DB.XYZ.BasisZ, pts[0]))
+        elif mode == "symbolic":
+            if not doc.IsFamilyDocument:
+                return routes.make_response(data={"error": "symbolic shapes require a family document"}, status=400)
+            sp = DB.SketchPlane.Create(doc, DB.Plane.CreateByNormalAndOrigin(DB.XYZ.BasisZ, pts[0]))
+        t = DB.Transaction(doc, "Create %s Shape" % mode); t.Start(); ids = []
+        for i in range(len(pts)):
+            ln = DB.Line.CreateBound(pts[i], pts[(i + 1) % len(pts)])
+            if mode == "detail":
+                ids.append(element_id_value(doc.Create.NewDetailCurve(view, ln).Id))
+            elif mode == "model":
+                ids.append(element_id_value(doc.Create.NewModelCurve(ln, sp).Id))
+            else:
+                ids.append(element_id_value(doc.FamilyCreate.NewSymbolicCurve(ln, sp).Id))
+        t.Commit()
+        return routes.make_response(data={"status": "success", "shape_type": shape, "curve_ids": ids})
+
+    @api.route("/create_detail_shapes/", methods=["POST"])
+    def create_detail_shapes(doc, request):
+        """Body: {shape_type:'rectangle|circle|polygon', center_x,center_y, width,height,radius,sides,rotation}"""
+        try: return _shapes(doc, request, "detail")
+        except Exception as e: return _err(e)
+
+    @api.route("/create_model_shapes/", methods=["POST"])
+    def create_model_shapes(doc, request):
+        try: return _shapes(doc, request, "model")
+        except Exception as e: return _err(e)
+
+    @api.route("/create_symbolic_shapes/", methods=["POST"])
+    def create_symbolic_shapes(doc, request):
+        try: return _shapes(doc, request, "symbolic")
+        except Exception as e: return _err(e)
+
+    @api.route("/place_detail_component/", methods=["POST"])
+    def place_detail_component(doc, request):
+        """Place a 2D detail-component family instance in a detail/drafting view.
+        Body: {family:'...', type:'...', x, y, view_name:'...', rotation:0}"""
+        try:
+            b = _parse(request)
+            sym = find_family_symbol_safely(doc, b.get("family"), b.get("type"))
+            if not sym:
+                return routes.make_response(data={"error": "detail component type not found"}, status=404)
+            view = _view(doc, b)
+            t = DB.Transaction(doc, "Place Detail Component"); t.Start()
+            if not sym.IsActive:
+                sym.Activate(); doc.Regenerate()
+            pt = DB.XYZ(float(b.get("x", 0)), float(b.get("y", 0)), 0)
+            inst = doc.Create.NewFamilyInstance(pt, sym, view)
+            if b.get("rotation"):
+                ax = DB.Line.CreateBound(pt, pt + DB.XYZ.BasisZ)
+                DB.ElementTransformUtils.RotateElement(doc, inst.Id, ax, math.radians(float(b["rotation"])))
+            t.Commit()
+            return routes.make_response(data={"status": "success", "element_id": element_id_value(inst.Id),
+                                              "view": get_element_name(view)})
+        except Exception as e: return _err(e)
+
+    @api.route("/create_filled_region/", methods=["POST"])
+    def create_filled_region(doc, request):
+        """Filled region from a boundary loop. Body: {boundary:[{x,y,z},...], view_name, type_name(opt)}"""
+        try:
+            b = _parse(request); view = _view(doc, b)
+            pts = [_pt(p) for p in b["boundary"]]
+            from System.Collections.Generic import List
+            loop = DB.CurveLoop()
+            for i in range(len(pts)):
+                loop.Append(DB.Line.CreateBound(pts[i], pts[(i + 1) % len(pts)]))
+            loops = List[DB.CurveLoop](); loops.Add(loop)
+            frt = None
+            for ft in DB.FilteredElementCollector(doc).OfClass(DB.FilledRegionType):
+                if not b.get("type_name") or get_element_name(ft) == b["type_name"]:
+                    frt = ft; break
+            if frt is None:
+                return routes.make_response(data={"error": "no FilledRegionType available"}, status=404)
+            t = DB.Transaction(doc, "Create Filled Region"); t.Start()
+            fr = DB.FilledRegion.Create(doc, frt.Id, view.Id, loops); t.Commit()
+            return routes.make_response(data={"status": "success", "filled_region_id": element_id_value(fr.Id),
+                                              "type": get_element_name(frt)})
+        except Exception as e: return _err(e)
+
+    @api.route("/create_masking_region/", methods=["POST"])
+    def create_masking_region(doc, request):
+        """Masking region (filled region whose type is masking, else first type).
+        Body: {boundary:[{x,y,z},...], view_name}"""
+        try:
+            b = _parse(request); view = _view(doc, b)
+            pts = [_pt(p) for p in b["boundary"]]
+            from System.Collections.Generic import List
+            loop = DB.CurveLoop()
+            for i in range(len(pts)):
+                loop.Append(DB.Line.CreateBound(pts[i], pts[(i + 1) % len(pts)]))
+            loops = List[DB.CurveLoop](); loops.Add(loop)
+            frt = None
+            for ft in DB.FilteredElementCollector(doc).OfClass(DB.FilledRegionType):
+                try:
+                    if ft.IsMasking:
+                        frt = ft; break
+                except Exception:
+                    pass
+                if frt is None:
+                    frt = ft
+            if frt is None:
+                return routes.make_response(data={"error": "no FilledRegionType available"}, status=404)
+            t = DB.Transaction(doc, "Create Masking Region"); t.Start()
+            fr = DB.FilledRegion.Create(doc, frt.Id, view.Id, loops); t.Commit()
+            return routes.make_response(data={"status": "success", "masking_region_id": element_id_value(fr.Id),
+                                              "type": get_element_name(frt)})
+        except Exception as e: return _err(e)
+
+    logger.info("Detailing routes registered successfully")

--- a/revit_mcp/geometry.py
+++ b/revit_mcp/geometry.py
@@ -1,0 +1,399 @@
+# -*- coding: UTF-8 -*-
+"""
+Geometry routes (curves, splines, arcs, points, transforms, curve math).
+Ported from the Revit-2026-MCP-Server C# command set. Units in FEET, angles in DEGREES.
+Curve-operation tools reference an existing curve element via 'curve_element_id'
+(its GeometryCurve). Creation tools make Model/Detail curves.
+"""
+
+from utils import get_element_name, element_id_value
+from pyrevit import routes, DB
+import json, math, traceback, logging
+
+logger = logging.getLogger(__name__)
+
+
+def _parse(request):
+    if not request or not request.data:
+        return {}
+    return json.loads(request.data) if isinstance(request.data, str) else request.data
+
+
+def _pt(d):
+    return DB.XYZ(float(d.get("x", 0)), float(d.get("y", 0)), float(d.get("z", 0)))
+
+
+def _ptlist(arr):
+    return [_pt(p) for p in arr]
+
+
+def _curve_elem(doc, eid):
+    el = doc.GetElement(DB.ElementId(int(eid)))
+    if not isinstance(el, DB.CurveElement):
+        return None, None
+    return el, el.GeometryCurve
+
+
+def _sketchplane_z(doc, origin):
+    pl = DB.Plane.CreateByNormalAndOrigin(DB.XYZ.BasisZ, origin)
+    return DB.SketchPlane.Create(doc, pl)
+
+
+def _new_like(doc, src_elem, new_curve):
+    """Create a model/detail curve element matching the source element's context."""
+    if isinstance(src_elem, DB.DetailCurve):
+        v = doc.GetElement(src_elem.OwnerViewId)
+        return doc.Create.NewDetailCurve(v, new_curve)
+    sp = src_elem.SketchPlane if isinstance(src_elem, DB.ModelCurve) else None
+    if sp is None:
+        sp = _sketchplane_z(doc, new_curve.GetEndPoint(0))
+    return doc.Create.NewModelCurve(new_curve, sp)
+
+
+def _resp(d):
+    return routes.make_response(data=d)
+
+
+def _err(e):
+    return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+
+def register_geometry_routes(api):
+
+    @api.route("/create_bounded_line/", methods=["POST"])
+    def create_bounded_line(doc, request):
+        """Model line. Body: {start:{x,y,z}, end:{x,y,z}}"""
+        try:
+            b = _parse(request)
+            a, c = _pt(b["start"]), _pt(b["end"])
+            t = DB.Transaction(doc, "Create Bounded Line"); t.Start()
+            mc = doc.Create.NewModelCurve(DB.Line.CreateBound(a, c), _sketchplane_z(doc, a))
+            t.Commit()
+            return _resp({"status": "success", "line_id": element_id_value(mc.Id)})
+        except Exception as e: return _err(e)
+
+    @api.route("/create_curves_from_points/", methods=["POST"])
+    def create_curves_from_points(doc, request):
+        """Connected model lines. Body: {points:[{x,y,z},...], closed:false}"""
+        try:
+            b = _parse(request); pts = _ptlist(b["points"]); closed = bool(b.get("closed"))
+            if len(pts) < 2: return routes.make_response(data={"error": "need >=2 points"}, status=400)
+            sp = _sketchplane_z(doc, pts[0])
+            t = DB.Transaction(doc, "Create Curves From Points"); t.Start()
+            ids = []
+            n = len(pts) if closed else len(pts) - 1
+            for i in range(n):
+                a = pts[i]; c = pts[0] if i == len(pts) - 1 else pts[i + 1]
+                ids.append(element_id_value(doc.Create.NewModelCurve(DB.Line.CreateBound(a, c), sp).Id))
+            t.Commit()
+            return _resp({"status": "success", "curve_ids": ids, "closed": closed})
+        except Exception as e: return _err(e)
+
+    @api.route("/create_hermite_spline/", methods=["POST"])
+    def create_hermite_spline(doc, request):
+        """Body: {points:[...], closed:false}"""
+        try:
+            b = _parse(request); pts = _ptlist(b["points"]); closed = bool(b.get("closed"))
+            from System.Collections.Generic import List
+            lp = List[DB.XYZ](pts)
+            sp = _sketchplane_z(doc, pts[0])
+            t = DB.Transaction(doc, "Create Hermite Spline"); t.Start()
+            spl = DB.HermiteSpline.Create(lp, closed)
+            mc = doc.Create.NewModelCurve(spl, sp); t.Commit()
+            return _resp({"status": "success", "spline_id": element_id_value(mc.Id), "points": len(pts)})
+        except Exception as e: return _err(e)
+
+    @api.route("/create_hermite_spline_with_tangents/", methods=["POST"])
+    def create_hermite_spline_with_tangents(doc, request):
+        """Body: {points:[...], start_tangent:{x,y,z}, end_tangent:{x,y,z}, closed:false}"""
+        try:
+            b = _parse(request); pts = _ptlist(b["points"]); closed = bool(b.get("closed"))
+            from System.Collections.Generic import List
+            lp = List[DB.XYZ](pts)
+            tan = DB.HermiteSplineTangents()
+            tan.StartTangent = _pt(b["start_tangent"]); tan.EndTangent = _pt(b["end_tangent"])
+            sp = _sketchplane_z(doc, pts[0])
+            t = DB.Transaction(doc, "Create Hermite Spline Tangents"); t.Start()
+            spl = DB.HermiteSpline.Create(lp, closed, tan)
+            mc = doc.Create.NewModelCurve(spl, sp); t.Commit()
+            return _resp({"status": "success", "spline_id": element_id_value(mc.Id)})
+        except Exception as e: return _err(e)
+
+    @api.route("/create_offset_curve/", methods=["POST"])
+    def create_offset_curve(doc, request):
+        """Body: {curve_element_id:int, offset:ft, normal:{x,y,z}=Z}"""
+        try:
+            b = _parse(request); el, cv = _curve_elem(doc, b["curve_element_id"])
+            if cv is None: return routes.make_response(data={"error": "not a curve element"}, status=400)
+            nrm = _pt(b["normal"]) if b.get("normal") else DB.XYZ.BasisZ
+            t = DB.Transaction(doc, "Offset Curve"); t.Start()
+            ne = _new_like(doc, el, cv.CreateOffset(float(b["offset"]), nrm)); t.Commit()
+            return _resp({"status": "success", "offset_curve_id": element_id_value(ne.Id)})
+        except Exception as e: return _err(e)
+
+    @api.route("/create_clone_curve/", methods=["POST"])
+    def create_clone_curve(doc, request):
+        """Body: {curve_element_id:int}"""
+        try:
+            b = _parse(request); el, cv = _curve_elem(doc, b["curve_element_id"])
+            if cv is None: return routes.make_response(data={"error": "not a curve element"}, status=400)
+            t = DB.Transaction(doc, "Clone Curve"); t.Start()
+            ne = _new_like(doc, el, cv.Clone()); t.Commit()
+            return _resp({"status": "success", "cloned_curve_id": element_id_value(ne.Id)})
+        except Exception as e: return _err(e)
+
+    @api.route("/create_grid_line/", methods=["POST"])
+    def create_grid_line(doc, request):
+        """Straight grid. Body: {start:{x,y,z}, end:{x,y,z}, name:'A'}"""
+        try:
+            b = _parse(request)
+            t = DB.Transaction(doc, "Create Grid Line"); t.Start()
+            g = DB.Grid.Create(doc, DB.Line.CreateBound(_pt(b["start"]), _pt(b["end"])))
+            if b.get("name"):
+                try: g.Name = b["name"]
+                except Exception: pass
+            t.Commit()
+            return _resp({"status": "success", "grid_id": element_id_value(g.Id), "name": get_element_name(g)})
+        except Exception as e: return _err(e)
+
+    @api.route("/create_grid_arc/", methods=["POST"])
+    def create_grid_arc(doc, request):
+        """Curved (radial) grid. Body: {center:{x,y,z}, radius:ft, start_angle:deg, end_angle:deg, name:'A'}"""
+        try:
+            b = _parse(request)
+            cen = _pt(b["center"]); r = float(b["radius"])
+            a0 = math.radians(float(b.get("start_angle", 0))); a1 = math.radians(float(b.get("end_angle", 90)))
+            arc = DB.Arc.Create(cen, r, a0, a1, DB.XYZ.BasisX, DB.XYZ.BasisY)
+            t = DB.Transaction(doc, "Create Grid Arc"); t.Start()
+            g = DB.Grid.Create(doc, arc)
+            if b.get("name"):
+                try: g.Name = b["name"]
+                except Exception: pass
+            t.Commit()
+            return _resp({"status": "success", "grid_id": element_id_value(g.Id), "name": get_element_name(g)})
+        except Exception as e: return _err(e)
+
+    @api.route("/create_point/", methods=["POST"])
+    def create_point(doc, request):
+        """Reference point (family docs). Body: {x,y,z}. In projects returns the coordinates."""
+        try:
+            b = _parse(request); p = _pt(b)
+            if doc.IsFamilyDocument:
+                t = DB.Transaction(doc, "Create Point"); t.Start()
+                rp = doc.FamilyCreate.NewReferencePoint(p); t.Commit()
+                return _resp({"status": "success", "reference_point_id": element_id_value(rp.Id),
+                              "point": {"x": p.X, "y": p.Y, "z": p.Z}})
+            return _resp({"status": "success", "note": "ReferencePoints require a family document",
+                          "point": {"x": p.X, "y": p.Y, "z": p.Z}})
+        except Exception as e: return _err(e)
+
+    @api.route("/create_point_on_element/", methods=["POST"])
+    def create_point_on_element(doc, request):
+        """Project a point onto an element's geometry, returning the nearest point + face reference.
+        Body: {element_id:int, point:{x,y,z}}"""
+        try:
+            b = _parse(request); el = doc.GetElement(DB.ElementId(int(b["element_id"]))); p = _pt(b["point"])
+            opt = DB.Options(); opt.ComputeReferences = True
+            best = None
+            geo = el.get_Geometry(opt)
+            def faces(g):
+                for o in g:
+                    if isinstance(o, DB.Solid):
+                        for f in o.Faces: yield f
+                    elif isinstance(o, DB.GeometryInstance):
+                        for x in faces(o.GetInstanceGeometry()): yield x
+            for f in faces(geo):
+                ir = f.Project(p)
+                if ir is not None and (best is None or ir.Distance < best[0]):
+                    best = (ir.Distance, ir.XYZPoint, f.Reference)
+            if best is None:
+                return routes.make_response(data={"error": "could not project onto element"}, status=404)
+            pt = best[1]
+            return _resp({"status": "success", "point": {"x": pt.X, "y": pt.Y, "z": pt.Z},
+                          "distance": round(best[0], 4),
+                          "reference": best[2].ConvertToStableRepresentation(doc) if best[2] else None})
+        except Exception as e: return _err(e)
+
+    @api.route("/calculate_line_direction/", methods=["POST"])
+    def calculate_line_direction(doc, request):
+        """Body: {start:{x,y,z}, end:{x,y,z}} -> normalized direction + length."""
+        try:
+            b = _parse(request); a, c = _pt(b["start"]), _pt(b["end"])
+            v = c - a; ln = v.GetLength(); d = v.Normalize()
+            return _resp({"status": "success", "direction": {"x": d.X, "y": d.Y, "z": d.Z}, "length": ln})
+        except Exception as e: return _err(e)
+
+    @api.route("/rotate_elements/", methods=["POST"])
+    def rotate_elements(doc, request):
+        """Body: {element_ids:[...], angle:deg, axis_point:{x,y,z}=origin, axis_dir:{x,y,z}=Z}"""
+        try:
+            from System.Collections.Generic import List
+            b = _parse(request)
+            ids = List[DB.ElementId]([DB.ElementId(int(i)) for i in b["element_ids"]])
+            ap = _pt(b["axis_point"]) if b.get("axis_point") else DB.XYZ.Zero
+            ad = _pt(b["axis_dir"]) if b.get("axis_dir") else DB.XYZ.BasisZ
+            axis = DB.Line.CreateUnbound(ap, ad)
+            t = DB.Transaction(doc, "Rotate Elements"); t.Start()
+            DB.ElementTransformUtils.RotateElements(doc, ids, axis, math.radians(float(b["angle"]))); t.Commit()
+            return _resp({"status": "success", "rotated": len(b["element_ids"]), "angle_deg": b["angle"]})
+        except Exception as e: return _err(e)
+
+    # ---- curve math (operate on an existing curve_element_id) ----
+    @api.route("/evaluate_curve/", methods=["POST"])
+    def evaluate_curve(doc, request):
+        """Body: {curve_element_id, parameter, normalized:false} -> point on curve."""
+        try:
+            b = _parse(request); el, cv = _curve_elem(doc, b["curve_element_id"])
+            if cv is None: return routes.make_response(data={"error": "not a curve element"}, status=400)
+            p = cv.Evaluate(float(b["parameter"]), bool(b.get("normalized", False)))
+            return _resp({"status": "success", "point": {"x": p.X, "y": p.Y, "z": p.Z}})
+        except Exception as e: return _err(e)
+
+    @api.route("/curve_distance_to_point/", methods=["POST"])
+    def curve_distance_to_point(doc, request):
+        """Body: {curve_element_id, point:{x,y,z}} -> distance."""
+        try:
+            b = _parse(request); el, cv = _curve_elem(doc, b["curve_element_id"])
+            if cv is None: return routes.make_response(data={"error": "not a curve element"}, status=400)
+            return _resp({"status": "success", "distance": cv.Distance(_pt(b["point"]))})
+        except Exception as e: return _err(e)
+
+    @api.route("/curve_get_end_point/", methods=["POST"])
+    def curve_get_end_point(doc, request):
+        """Body: {curve_element_id, end:0|1}"""
+        try:
+            b = _parse(request); el, cv = _curve_elem(doc, b["curve_element_id"])
+            if cv is None: return routes.make_response(data={"error": "not a curve element"}, status=400)
+            p = cv.GetEndPoint(int(b.get("end", 0)))
+            return _resp({"status": "success", "point": {"x": p.X, "y": p.Y, "z": p.Z}})
+        except Exception as e: return _err(e)
+
+    @api.route("/curve_get_end_parameter/", methods=["POST"])
+    def curve_get_end_parameter(doc, request):
+        try:
+            b = _parse(request); el, cv = _curve_elem(doc, b["curve_element_id"])
+            if cv is None: return routes.make_response(data={"error": "not a curve element"}, status=400)
+            return _resp({"status": "success", "parameter": cv.GetEndParameter(int(b.get("end", 0)))})
+        except Exception as e: return _err(e)
+
+    @api.route("/curve_get_end_point_reference/", methods=["POST"])
+    def curve_get_end_point_reference(doc, request):
+        """Returns a stable Reference to a curve endpoint (for dimensioning/constraints)."""
+        try:
+            b = _parse(request); el, cv = _curve_elem(doc, b["curve_element_id"])
+            if cv is None: return routes.make_response(data={"error": "not a curve element"}, status=400)
+            r = cv.GetEndPointReference(int(b.get("end", 0)))
+            return _resp({"status": "success", "reference": r.ConvertToStableRepresentation(doc) if r else None})
+        except Exception as e: return _err(e)
+
+    @api.route("/curve_compute_derivatives/", methods=["POST"])
+    def curve_compute_derivatives(doc, request):
+        """Body: {curve_element_id, parameter, normalized:false} -> origin + 1st/2nd derivative vectors."""
+        try:
+            b = _parse(request); el, cv = _curve_elem(doc, b["curve_element_id"])
+            if cv is None: return routes.make_response(data={"error": "not a curve element"}, status=400)
+            tr = cv.ComputeDerivatives(float(b["parameter"]), bool(b.get("normalized", False)))
+            v = lambda x: {"x": x.X, "y": x.Y, "z": x.Z}
+            return _resp({"status": "success", "origin": v(tr.Origin), "first": v(tr.BasisX),
+                          "second": v(tr.BasisY)})
+        except Exception as e: return _err(e)
+
+    @api.route("/curve_compute_normalized_parameter/", methods=["POST"])
+    def curve_compute_normalized_parameter(doc, request):
+        try:
+            b = _parse(request); el, cv = _curve_elem(doc, b["curve_element_id"])
+            if cv is None: return routes.make_response(data={"error": "not a curve element"}, status=400)
+            return _resp({"status": "success", "normalized": cv.ComputeNormalizedParameter(float(b["raw_parameter"]))})
+        except Exception as e: return _err(e)
+
+    @api.route("/curve_compute_raw_parameter/", methods=["POST"])
+    def curve_compute_raw_parameter(doc, request):
+        try:
+            b = _parse(request); el, cv = _curve_elem(doc, b["curve_element_id"])
+            if cv is None: return routes.make_response(data={"error": "not a curve element"}, status=400)
+            return _resp({"status": "success", "raw": cv.ComputeRawParameter(float(b["normalized_parameter"]))})
+        except Exception as e: return _err(e)
+
+    @api.route("/curve_point_location_on_curve/", methods=["POST"])
+    def curve_point_location_on_curve(doc, request):
+        """Project a point onto the curve. Body: {curve_element_id, point:{x,y,z}}"""
+        try:
+            b = _parse(request); el, cv = _curve_elem(doc, b["curve_element_id"])
+            if cv is None: return routes.make_response(data={"error": "not a curve element"}, status=400)
+            ir = cv.Project(_pt(b["point"]))
+            if ir is None: return routes.make_response(data={"error": "projection failed"}, status=404)
+            p = ir.XYZPoint
+            return _resp({"status": "success", "point": {"x": p.X, "y": p.Y, "z": p.Z},
+                          "parameter": ir.Parameter, "distance": ir.Distance})
+        except Exception as e: return _err(e)
+
+    @api.route("/curve_compute_closest_points/", methods=["POST"])
+    def curve_compute_closest_points(doc, request):
+        """Closest approach between two curve elements (best-effort via endpoint projection).
+        Body: {curve_element_id_a, curve_element_id_b}"""
+        try:
+            b = _parse(request)
+            _, ca = _curve_elem(doc, b["curve_element_id_a"])
+            _, cb = _curve_elem(doc, b["curve_element_id_b"])
+            if ca is None or cb is None: return routes.make_response(data={"error": "need two curve elements"}, status=400)
+            best = None
+            for src, dst in ((ca, cb), (cb, ca)):
+                for u in (0.0, 0.25, 0.5, 0.75, 1.0):
+                    p = src.Evaluate(u, True); ir = dst.Project(p)
+                    if ir and (best is None or ir.Distance < best["distance"]):
+                        q = ir.XYZPoint
+                        best = {"distance": ir.Distance, "point_a": {"x": p.X, "y": p.Y, "z": p.Z},
+                                "point_b": {"x": q.X, "y": q.Y, "z": q.Z}}
+            return _resp({"status": "success", "closest": best})
+        except Exception as e: return _err(e)
+
+    @api.route("/curve_create_reversed/", methods=["POST"])
+    def curve_create_reversed(doc, request):
+        """Body: {curve_element_id} -> new reversed curve element."""
+        try:
+            b = _parse(request); el, cv = _curve_elem(doc, b["curve_element_id"])
+            if cv is None: return routes.make_response(data={"error": "not a curve element"}, status=400)
+            t = DB.Transaction(doc, "Reverse Curve"); t.Start()
+            ne = _new_like(doc, el, cv.CreateReversed()); t.Commit()
+            return _resp({"status": "success", "reversed_curve_id": element_id_value(ne.Id)})
+        except Exception as e: return _err(e)
+
+    @api.route("/curve_create_transformed/", methods=["POST"])
+    def curve_create_transformed(doc, request):
+        """Body: {curve_element_id, translation:{x,y,z}, rotation_deg:0, axis_point:{}, axis_dir:{}}"""
+        try:
+            b = _parse(request); el, cv = _curve_elem(doc, b["curve_element_id"])
+            if cv is None: return routes.make_response(data={"error": "not a curve element"}, status=400)
+            xf = DB.Transform.Identity
+            if b.get("rotation_deg"):
+                ap = _pt(b["axis_point"]) if b.get("axis_point") else DB.XYZ.Zero
+                ad = _pt(b["axis_dir"]) if b.get("axis_dir") else DB.XYZ.BasisZ
+                xf = DB.Transform.CreateRotationAtPoint(ad, math.radians(float(b["rotation_deg"])), ap)
+            if b.get("translation"):
+                xf = DB.Transform.CreateTranslation(_pt(b["translation"])).Multiply(xf)
+            t = DB.Transaction(doc, "Transform Curve"); t.Start()
+            ne = _new_like(doc, el, cv.CreateTransformed(xf)); t.Commit()
+            return _resp({"status": "success", "transformed_curve_id": element_id_value(ne.Id)})
+        except Exception as e: return _err(e)
+
+    @api.route("/curve_intersect/", methods=["POST"])
+    def curve_intersect(doc, request):
+        """Intersection of two curve elements. Body: {curve_element_id_a, curve_element_id_b}"""
+        try:
+            b = _parse(request)
+            _, ca = _curve_elem(doc, b["curve_element_id_a"])
+            _, cb = _curve_elem(doc, b["curve_element_id_b"])
+            if ca is None or cb is None: return routes.make_response(data={"error": "need two curve elements"}, status=400)
+            # IronPython returns the .NET out-parameter as part of a tuple
+            comp, arr = ca.Intersect(cb)
+            pts = []
+            if arr is not None:
+                try:
+                    for ir in arr:
+                        p = ir.XYZPoint; pts.append({"x": p.X, "y": p.Y, "z": p.Z})
+                except Exception:
+                    pass
+            return _resp({"status": "success", "result": str(comp), "points": pts})
+        except Exception as e: return _err(e)
+
+    logger.info("Geometry routes registered successfully")

--- a/revit_mcp/interop.py
+++ b/revit_mcp/interop.py
@@ -1,0 +1,229 @@
+# -*- coding: UTF-8 -*-
+"""
+Interop Module for Revit MCP
+Handles IFC export and external file linking/importing
+"""
+
+from utils import get_element_name, get_element_id_value
+from pyrevit import routes, revit, DB
+import json
+import os
+import traceback
+import logging
+
+logger = logging.getLogger(__name__)
+
+MM_TO_FEET = 1.0 / 304.8
+
+
+def register_interop_routes(api):
+    """Register all interop routes with the API"""
+
+    @api.route("/export_ifc/", methods=["POST"])
+    def export_ifc_handler(doc, request):
+        """Export the model to IFC format."""
+        try:
+            if not doc:
+                return routes.make_response(
+                    data={"error": "No active Revit document"}, status=503
+                )
+
+            data = json.loads(request.data) if isinstance(request.data, str) else request.data
+
+            file_path = data.get("file_path")
+            if not file_path:
+                return routes.make_response(
+                    data={"error": "file_path is required (must end in .ifc)"},
+                    status=400,
+                )
+
+            if not file_path.lower().endswith(".ifc"):
+                return routes.make_response(
+                    data={"error": "file_path must end in .ifc"},
+                    status=400,
+                )
+
+            ifc_version = data.get("ifc_version", "IFC2x3")
+            export_base_quantities = data.get("export_base_quantities", True)
+            view_name = data.get("view_name")
+
+            # Ensure output directory exists
+            output_dir = os.path.dirname(file_path)
+            file_name = os.path.basename(file_path)
+
+            if output_dir and not os.path.exists(output_dir):
+                try:
+                    os.makedirs(output_dir)
+                except Exception as dir_err:
+                    return routes.make_response(
+                        data={"error": "Cannot create output directory: {}".format(str(dir_err))},
+                        status=500,
+                    )
+
+            # Set up IFC export options
+            ifc_options = DB.IFCExportOptions()
+
+            # Set IFC version
+            if ifc_version == "IFC4":
+                ifc_options.FileVersion = DB.IFCVersion.IFC4
+            else:
+                ifc_options.FileVersion = DB.IFCVersion.IFC2x3
+
+            ifc_options.ExportBaseQuantities = export_base_quantities
+
+            # Filter by view if specified
+            if view_name:
+                views = (
+                    DB.FilteredElementCollector(doc)
+                    .OfClass(DB.View)
+                    .WhereElementIsNotElementType()
+                    .ToElements()
+                )
+                target_view = None
+                for v in views:
+                    if get_element_name(v) == view_name and not v.IsTemplate:
+                        target_view = v
+                        break
+                if target_view:
+                    ifc_options.FilterViewId = target_view.Id
+
+            t = DB.Transaction(doc, "Export IFC via MCP")
+            t.Start()
+
+            try:
+                doc.Export(output_dir or ".", file_name, ifc_options)
+                t.Commit()
+            except Exception as tx_error:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                raise tx_error
+
+            # Get file size
+            file_size_kb = 0
+            try:
+                if os.path.exists(file_path):
+                    file_size_kb = int(os.path.getsize(file_path) / 1024)
+            except Exception:
+                pass
+
+            return routes.make_response(
+                data={
+                    "status": "success",
+                    "file_path": file_path,
+                    "file_size_kb": file_size_kb,
+                    "ifc_version": ifc_version,
+                    "message": "Exported IFC to '{}' ({} KB)".format(file_path, file_size_kb),
+                }
+            )
+
+        except Exception as e:
+            logger.error("Failed to export IFC: {}".format(str(e)))
+            error_trace = traceback.format_exc()
+            return routes.make_response(
+                data={"error": str(e), "traceback": error_trace}, status=500
+            )
+
+    @api.route("/link_file/", methods=["POST"])
+    def link_file_handler(doc, request):
+        """Link or import an external file."""
+        try:
+            if not doc:
+                return routes.make_response(
+                    data={"error": "No active Revit document"}, status=503
+                )
+
+            data = json.loads(request.data) if isinstance(request.data, str) else request.data
+
+            file_path = data.get("file_path")
+            if not file_path:
+                return routes.make_response(
+                    data={"error": "file_path is required"},
+                    status=400,
+                )
+
+            if not os.path.exists(file_path):
+                return routes.make_response(
+                    data={"error": "File not found at the specified path."},
+                    status=500,
+                )
+
+            mode = data.get("mode", "link")
+            position = data.get("position")
+
+            file_ext = os.path.splitext(file_path)[1].lower()
+            file_name = os.path.basename(file_path)
+            file_type = file_ext.lstrip(".").upper()
+
+            t = DB.Transaction(doc, "Link/Import File via MCP")
+            t.Start()
+
+            try:
+                result_id = None
+
+                if file_ext == ".rvt":
+                    # Revit link
+                    model_path = DB.ModelPathUtils.ConvertUserVisiblePathToModelPath(file_path)
+                    link_options = DB.RevitLinkOptions(False)  # not relative
+                    link_result = DB.RevitLinkType.Create(doc, model_path, link_options)
+                    if link_result and link_result.ElementId:
+                        result_id = get_element_id_value(link_result.ElementId)
+                        # Place instance
+                        link_instance = DB.RevitLinkInstance.Create(doc, link_result.ElementId)
+                        if link_instance:
+                            result_id = get_element_id_value(link_instance)
+
+                elif file_ext in (".dwg", ".dxf", ".dgn"):
+                    # CAD file
+                    options = DB.DWGImportOptions()
+                    options.Placement = DB.ImportPlacement.Origin
+
+                    if position:
+                        # Will be applied after import via move
+                        pass
+
+                    active_view = doc.ActiveView
+                    linked_id = None  # clr.Reference[DB.ElementId]()
+
+                    if mode == "import":
+                        success = doc.Import(file_path, options, active_view, linked_id)
+                    else:
+                        success = doc.Link(file_path, options, active_view, linked_id)
+
+                    if linked_id:
+                        result_id = get_element_id_value(linked_id)
+
+                else:
+                    t.RollBack()
+                    return routes.make_response(
+                        data={"error": "Unsupported file type '{}'. Supported: DWG, DXF, DGN, RVT".format(file_ext)},
+                        status=400,
+                    )
+
+                t.Commit()
+
+                return routes.make_response(
+                    data={
+                        "status": "success",
+                        "element_id": result_id,
+                        "file_name": file_name,
+                        "file_type": file_type,
+                        "mode": mode,
+                        "message": "{}ed file '{}'".format(
+                            mode.capitalize(), file_name
+                        ),
+                    }
+                )
+
+            except Exception as tx_error:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                raise tx_error
+
+        except Exception as e:
+            logger.error("Failed to link file: {}".format(str(e)))
+            error_trace = traceback.format_exc()
+            return routes.make_response(
+                data={"error": str(e), "traceback": error_trace}, status=500
+            )
+
+    logger.info("Interop routes registered successfully")

--- a/revit_mcp/mep.py
+++ b/revit_mcp/mep.py
@@ -1,0 +1,501 @@
+# -*- coding: UTF-8 -*-
+"""
+MEP Module for Revit MCP
+Handles duct, pipe, and MEP system creation
+"""
+
+from utils import get_element_name, get_element_id_value, make_element_id
+from pyrevit import routes, revit, DB
+import json
+import traceback
+import logging
+
+logger = logging.getLogger(__name__)
+
+MM_TO_FEET = 1.0 / 304.8
+
+
+def register_mep_routes(api):
+    """Register all MEP routes with the API"""
+
+    @api.route("/create_duct/", methods=["POST"])
+    def create_duct_handler(doc, request):
+        """Create a duct between two points."""
+        try:
+            if not doc:
+                return routes.make_response(
+                    data={"error": "No active Revit document"}, status=503
+                )
+
+            data = json.loads(request.data) if isinstance(request.data, str) else request.data
+
+            start_point = data.get("start_point")
+            end_point = data.get("end_point")
+            if not start_point or not end_point:
+                return routes.make_response(
+                    data={"error": "start_point and end_point are required"},
+                    status=400,
+                )
+
+            # Convert points
+            start = DB.XYZ(
+                float(start_point.get("x", 0)) * MM_TO_FEET,
+                float(start_point.get("y", 0)) * MM_TO_FEET,
+                float(start_point.get("z", 0)) * MM_TO_FEET,
+            )
+            end = DB.XYZ(
+                float(end_point.get("x", 0)) * MM_TO_FEET,
+                float(end_point.get("y", 0)) * MM_TO_FEET,
+                float(end_point.get("z", 0)) * MM_TO_FEET,
+            )
+
+            # Find duct type
+            duct_type_name = data.get("duct_type")
+            duct_types = (
+                DB.FilteredElementCollector(doc)
+                .OfClass(DB.Mechanical.DuctType)
+                .ToElements()
+            )
+
+            if not duct_types:
+                return routes.make_response(
+                    data={"error": "No duct types available — load a mechanical template or family first."},
+                    status=500,
+                )
+
+            target_duct_type = None
+            if duct_type_name:
+                for dt in duct_types:
+                    if get_element_name(dt) == duct_type_name:
+                        target_duct_type = dt
+                        break
+                if not target_duct_type:
+                    available = [get_element_name(dt) for dt in duct_types]
+                    return routes.make_response(
+                        data={
+                            "error": "Duct type '{}' not found".format(duct_type_name),
+                            "available_duct_types": available,
+                        },
+                        status=404,
+                    )
+            else:
+                target_duct_type = duct_types[0]
+
+            # Find mechanical system type
+            system_type_name = data.get("system_type")
+            mech_system_types = (
+                DB.FilteredElementCollector(doc)
+                .OfClass(DB.Mechanical.MechanicalSystemType)
+                .ToElements()
+            )
+
+            target_system_type = None
+            if mech_system_types:
+                if system_type_name:
+                    for st in mech_system_types:
+                        if get_element_name(st) == system_type_name:
+                            target_system_type = st
+                            break
+                if not target_system_type:
+                    target_system_type = mech_system_types[0]
+
+            # Find level
+            level_name = data.get("level_name")
+            levels = (
+                DB.FilteredElementCollector(doc)
+                .OfCategory(DB.BuiltInCategory.OST_Levels)
+                .WhereElementIsNotElementType()
+                .ToElements()
+            )
+            target_level = None
+            if level_name:
+                for lv in levels:
+                    if get_element_name(lv) == level_name:
+                        target_level = lv
+                        break
+            if not target_level and levels:
+                # Use nearest level by elevation
+                z_elev = start.Z
+                target_level = min(levels, key=lambda lv: abs(lv.Elevation - z_elev))
+
+            if not target_level:
+                return routes.make_response(
+                    data={"error": "No levels found in the project"},
+                    status=500,
+                )
+
+            t = DB.Transaction(doc, "Create Duct via MCP")
+            t.Start()
+
+            try:
+                sys_type_id = target_system_type.Id if target_system_type else DB.ElementId.InvalidElementId
+                duct = DB.Mechanical.Duct.Create(
+                    doc,
+                    sys_type_id,
+                    target_duct_type.Id,
+                    target_level.Id,
+                    start,
+                    end,
+                )
+
+                # Set diameter or dimensions if specified
+                diameter = data.get("diameter")
+                width = data.get("width")
+                height = data.get("height")
+
+                if diameter:
+                    d_param = duct.LookupParameter("Diameter")
+                    if d_param and not d_param.IsReadOnly:
+                        d_param.Set(float(diameter) * MM_TO_FEET)
+
+                if width:
+                    w_param = duct.LookupParameter("Width")
+                    if w_param and not w_param.IsReadOnly:
+                        w_param.Set(float(width) * MM_TO_FEET)
+
+                if height:
+                    h_param = duct.LookupParameter("Height")
+                    if h_param and not h_param.IsReadOnly:
+                        h_param.Set(float(height) * MM_TO_FEET)
+
+                t.Commit()
+
+                return routes.make_response(
+                    data={
+                        "status": "success",
+                        "duct_id": get_element_id_value(duct),
+                        "system_type": get_element_name(target_system_type) if target_system_type else "None",
+                        "duct_type": get_element_name(target_duct_type),
+                        "level": get_element_name(target_level),
+                        "message": "Created duct on level '{}'".format(get_element_name(target_level)),
+                    }
+                )
+
+            except Exception as tx_error:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                raise tx_error
+
+        except Exception as e:
+            logger.error("Failed to create duct: {}".format(str(e)))
+            error_trace = traceback.format_exc()
+            return routes.make_response(
+                data={"error": str(e), "traceback": error_trace}, status=500
+            )
+
+    @api.route("/create_pipe/", methods=["POST"])
+    def create_pipe_handler(doc, request):
+        """Create a pipe between two points."""
+        try:
+            if not doc:
+                return routes.make_response(
+                    data={"error": "No active Revit document"}, status=503
+                )
+
+            data = json.loads(request.data) if isinstance(request.data, str) else request.data
+
+            start_point = data.get("start_point")
+            end_point = data.get("end_point")
+            if not start_point or not end_point:
+                return routes.make_response(
+                    data={"error": "start_point and end_point are required"},
+                    status=400,
+                )
+
+            start = DB.XYZ(
+                float(start_point.get("x", 0)) * MM_TO_FEET,
+                float(start_point.get("y", 0)) * MM_TO_FEET,
+                float(start_point.get("z", 0)) * MM_TO_FEET,
+            )
+            end = DB.XYZ(
+                float(end_point.get("x", 0)) * MM_TO_FEET,
+                float(end_point.get("y", 0)) * MM_TO_FEET,
+                float(end_point.get("z", 0)) * MM_TO_FEET,
+            )
+
+            # Find pipe type
+            pipe_type_name = data.get("pipe_type")
+            pipe_types = (
+                DB.FilteredElementCollector(doc)
+                .OfClass(DB.Plumbing.PipeType)
+                .ToElements()
+            )
+
+            if not pipe_types:
+                return routes.make_response(
+                    data={"error": "No pipe types available — load a plumbing template or family first."},
+                    status=500,
+                )
+
+            target_pipe_type = None
+            if pipe_type_name:
+                for pt in pipe_types:
+                    if get_element_name(pt) == pipe_type_name:
+                        target_pipe_type = pt
+                        break
+                if not target_pipe_type:
+                    available = [get_element_name(pt) for pt in pipe_types]
+                    return routes.make_response(
+                        data={
+                            "error": "Pipe type '{}' not found".format(pipe_type_name),
+                            "available_pipe_types": available,
+                        },
+                        status=404,
+                    )
+            else:
+                target_pipe_type = pipe_types[0]
+
+            # Find piping system type
+            system_type_name = data.get("system_type")
+            piping_system_types = (
+                DB.FilteredElementCollector(doc)
+                .OfClass(DB.Plumbing.PipingSystemType)
+                .ToElements()
+            )
+
+            target_system_type = None
+            if piping_system_types:
+                if system_type_name:
+                    for st in piping_system_types:
+                        if get_element_name(st) == system_type_name:
+                            target_system_type = st
+                            break
+                if not target_system_type:
+                    target_system_type = piping_system_types[0]
+
+            # Find level
+            level_name = data.get("level_name")
+            levels = (
+                DB.FilteredElementCollector(doc)
+                .OfCategory(DB.BuiltInCategory.OST_Levels)
+                .WhereElementIsNotElementType()
+                .ToElements()
+            )
+            target_level = None
+            if level_name:
+                for lv in levels:
+                    if get_element_name(lv) == level_name:
+                        target_level = lv
+                        break
+            if not target_level and levels:
+                z_elev = start.Z
+                target_level = min(levels, key=lambda lv: abs(lv.Elevation - z_elev))
+
+            if not target_level:
+                return routes.make_response(
+                    data={"error": "No levels found in the project"},
+                    status=500,
+                )
+
+            t = DB.Transaction(doc, "Create Pipe via MCP")
+            t.Start()
+
+            try:
+                sys_type_id = target_system_type.Id if target_system_type else DB.ElementId.InvalidElementId
+                pipe = DB.Plumbing.Pipe.Create(
+                    doc,
+                    sys_type_id,
+                    target_pipe_type.Id,
+                    target_level.Id,
+                    start,
+                    end,
+                )
+
+                # Set diameter if specified
+                diameter = data.get("diameter")
+                if diameter:
+                    d_param = pipe.LookupParameter("Diameter")
+                    if d_param and not d_param.IsReadOnly:
+                        d_param.Set(float(diameter) * MM_TO_FEET)
+
+                t.Commit()
+
+                return routes.make_response(
+                    data={
+                        "status": "success",
+                        "pipe_id": get_element_id_value(pipe),
+                        "system_type": get_element_name(target_system_type) if target_system_type else "None",
+                        "pipe_type": get_element_name(target_pipe_type),
+                        "level": get_element_name(target_level),
+                        "message": "Created pipe on level '{}'".format(get_element_name(target_level)),
+                    }
+                )
+
+            except Exception as tx_error:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                raise tx_error
+
+        except Exception as e:
+            logger.error("Failed to create pipe: {}".format(str(e)))
+            error_trace = traceback.format_exc()
+            return routes.make_response(
+                data={"error": str(e), "traceback": error_trace}, status=500
+            )
+
+    @api.route("/create_mep_system/", methods=["POST"])
+    def create_mep_system_handler(doc, request):
+        """Create a mechanical or piping system."""
+        try:
+            if not doc:
+                return routes.make_response(
+                    data={"error": "No active Revit document"}, status=503
+                )
+
+            data = json.loads(request.data) if isinstance(request.data, str) else request.data
+
+            system_type = data.get("system_type")
+            system_name = data.get("system_name")
+
+            if not system_type:
+                return routes.make_response(
+                    data={"error": "system_type is required (mechanical or piping)"},
+                    status=400,
+                )
+            if not system_name:
+                return routes.make_response(
+                    data={"error": "system_name is required"},
+                    status=400,
+                )
+            if system_type not in ("mechanical", "piping"):
+                return routes.make_response(
+                    data={"error": "system_type must be 'mechanical' or 'piping'"},
+                    status=400,
+                )
+
+            # Collect element IDs if provided
+            element_ids = data.get("element_ids", [])
+            connector_set = None
+
+            if element_ids:
+                # Get connectors from the specified elements
+                for eid in element_ids:
+                    elem_id = make_element_id(eid)
+                    elem = doc.GetElement(elem_id)
+                    if not elem:
+                        return routes.make_response(
+                            data={"error": "Element {} not found".format(eid)},
+                            status=404,
+                        )
+
+            t = DB.Transaction(doc, "Create MEP System via MCP")
+            t.Start()
+
+            try:
+                new_system = None
+
+                if not element_ids:
+                    t.RollBack()
+                    return routes.make_response(
+                        data={
+                            "error": "element_ids is required. Provide IDs of ducts/pipes to group into a system.",
+                            "hint": "Create ducts or pipes first, then group them.",
+                        },
+                        status=400,
+                    )
+
+                # Find existing MEP systems from the provided elements
+                existing_systems = set()
+                for eid in element_ids:
+                    elem = doc.GetElement(make_element_id(eid))
+                    if not elem:
+                        continue
+                    # Check connectors for existing system assignments
+                    conn_mgr = None
+                    if hasattr(elem, "ConnectorManager"):
+                        conn_mgr = elem.ConnectorManager
+                    elif hasattr(elem, "MEPModel") and elem.MEPModel:
+                        conn_mgr = elem.MEPModel.ConnectorManager
+                    if conn_mgr:
+                        for c in conn_mgr.Connectors:
+                            if hasattr(c, "MEPSystem") and c.MEPSystem:
+                                existing_systems.add(get_element_id_value(c.MEPSystem))
+
+                if existing_systems:
+                    # Rename the first existing system
+                    sys_id = list(existing_systems)[0]
+                    new_system = doc.GetElement(make_element_id(sys_id))
+                    if new_system:
+                        name_param = new_system.LookupParameter("System Name")
+                        if not name_param:
+                            name_param = new_system.LookupParameter("Comments")
+                        if name_param and not name_param.IsReadOnly:
+                            name_param.Set(system_name)
+                else:
+                    # Try to create a new system with unused connectors
+                    first_connector = None
+                    unused_connectors = DB.ConnectorSet()
+                    for eid in element_ids:
+                        elem = doc.GetElement(make_element_id(eid))
+                        if not elem:
+                            continue
+                        conn_mgr = None
+                        if hasattr(elem, "ConnectorManager"):
+                            conn_mgr = elem.ConnectorManager
+                        elif hasattr(elem, "MEPModel") and elem.MEPModel:
+                            conn_mgr = elem.MEPModel.ConnectorManager
+                        if conn_mgr:
+                            for c in conn_mgr.Connectors:
+                                if not hasattr(c, "MEPSystem") or not c.MEPSystem:
+                                    unused_connectors.Insert(c)
+                                    if not first_connector:
+                                        first_connector = c
+
+                    if first_connector:
+                        if system_type == "mechanical":
+                            duct_enum = DB.Mechanical.DuctSystemType.SupplyAir
+                            new_system = doc.Create.NewMechanicalSystem(
+                                first_connector, unused_connectors, duct_enum
+                            )
+                        elif system_type == "piping":
+                            pipe_enum = DB.Plumbing.PipeSystemType.DomesticHotWater
+                            new_system = doc.Create.NewPipingSystem(
+                                first_connector, unused_connectors, pipe_enum
+                            )
+                    else:
+                        t.RollBack()
+                        return routes.make_response(
+                            data={
+                                "error": "All connectors are already assigned to systems and could not be renamed.",
+                            },
+                            status=500,
+                        )
+
+                # Set system name
+                if new_system:
+                    name_param = new_system.LookupParameter("System Name")
+                    if name_param and not name_param.IsReadOnly:
+                        name_param.Set(system_name)
+
+                t.Commit()
+
+                if new_system:
+                    return routes.make_response(
+                        data={
+                            "status": "success",
+                            "system_id": get_element_id_value(new_system),
+                            "system_name": system_name,
+                            "system_type": system_type,
+                            "element_count": len(element_ids),
+                            "message": "Created {} system '{}'".format(system_type, system_name),
+                        }
+                    )
+                else:
+                    return routes.make_response(
+                        data={"error": "Failed to create {} system".format(system_type)},
+                        status=500,
+                    )
+
+            except Exception as tx_error:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                raise tx_error
+
+        except Exception as e:
+            logger.error("Failed to create MEP system: {}".format(str(e)))
+            error_trace = traceback.format_exc()
+            return routes.make_response(
+                data={"error": str(e), "traceback": error_trace}, status=500
+            )
+
+    logger.info("MEP routes registered successfully")

--- a/revit_mcp/parameters.py
+++ b/revit_mcp/parameters.py
@@ -1,0 +1,318 @@
+# -*- coding: UTF-8 -*-
+"""
+Parameters Module for Revit MCP
+Handles reading element properties and setting parameter values
+"""
+
+from utils import get_element_name, get_element_id_value, make_element_id
+from pyrevit import routes, revit, DB
+import json
+import traceback
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _safe_str(value):
+    """Convert a value to a JSON-safe ASCII string, replacing problematic chars.
+    IronPython 2.7 compatible — handles both str (bytes) and unicode."""
+    try:
+        if value is None:
+            return ""
+        # Try unicode first (IronPython 2.7 has unicode type)
+        try:
+            s = unicode(value)
+        except Exception:
+            try:
+                s = str(value)
+            except Exception:
+                return ""
+        # Strip any char with ordinal >= 128
+        result = []
+        for ch in s:
+            try:
+                o = ord(ch)
+                if o < 128:
+                    result.append(chr(o))
+                else:
+                    result.append("?")
+            except Exception:
+                result.append("?")
+        return "".join(result)
+    except Exception:
+        return ""
+
+
+def _get_param_group_name(param):
+    """Get the parameter group name safely across Revit versions."""
+    try:
+        # Revit 2024+
+        if hasattr(param.Definition, "GetGroupTypeId"):
+            group_id = param.Definition.GetGroupTypeId()
+            return _safe_str(DB.LabelUtils.GetLabelForGroup(group_id))
+        # Older Revit
+        if hasattr(param.Definition, "ParameterGroup"):
+            return _safe_str(param.Definition.ParameterGroup)
+    except Exception:
+        pass
+    return "Other"
+
+
+def _get_param_value_display(param, doc):
+    """Get a display-friendly parameter value."""
+    try:
+        if not param.HasValue:
+            return ""
+        if param.StorageType == DB.StorageType.String:
+            return _safe_str(param.AsString() or "")
+        elif param.StorageType == DB.StorageType.Integer:
+            display = param.AsValueString()
+            if display:
+                return _safe_str(display)
+            return str(param.AsInteger())
+        elif param.StorageType == DB.StorageType.Double:
+            display = param.AsValueString()
+            if display:
+                return _safe_str(display)
+            return str(round(param.AsDouble(), 6))
+        elif param.StorageType == DB.StorageType.ElementId:
+            eid = param.AsElementId()
+            if eid and eid != DB.ElementId.InvalidElementId:
+                elem = doc.GetElement(eid)
+                if elem:
+                    return _safe_str(get_element_name(elem))
+            return ""
+    except Exception:
+        return ""
+    return ""
+
+
+def register_parameter_routes(api):
+    """Register all parameter routes with the API"""
+
+    @api.route("/element_properties/<element_id>", methods=["GET"])
+    def get_element_properties_handler(doc, element_id):
+        """Get all properties and parameters of an element."""
+        try:
+            if not doc:
+                return routes.make_response(
+                    data={"error": "No active Revit document"}, status=503
+                )
+
+            elem_id = make_element_id(int(element_id))
+            elem = doc.GetElement(elem_id)
+            if not elem:
+                return routes.make_response(
+                    data={"error": "Element not found."},
+                    status=404,
+                )
+
+            category = ""
+            try:
+                if elem.Category:
+                    category = _safe_str(elem.Category.Name)
+            except Exception:
+                pass
+
+            family = ""
+            type_name = ""
+            try:
+                type_id = elem.GetTypeId()
+                if type_id and type_id != DB.ElementId.InvalidElementId:
+                    elem_type = doc.GetElement(type_id)
+                    if elem_type:
+                        type_name = _safe_str(get_element_name(elem_type))
+                        if hasattr(elem_type, "Family") and elem_type.Family:
+                            family = _safe_str(get_element_name(elem_type.Family))
+                        elif hasattr(elem_type, "FamilyName"):
+                            family = _safe_str(elem_type.FamilyName)
+            except Exception:
+                pass
+
+            # Collect instance parameters
+            parameters = []
+            seen_names = set()
+
+            for param in elem.GetOrderedParameters():
+                try:
+                    param_name = _safe_str(param.Definition.Name)
+                    if param_name in seen_names:
+                        continue
+                    seen_names.add(param_name)
+
+                    parameters.append({
+                        "name": param_name,
+                        "value": _safe_str(_get_param_value_display(param, doc)),
+                        "storage_type": str(param.StorageType),
+                        "read_only": param.IsReadOnly,
+                        "group": _safe_str(_get_param_group_name(param)),
+                        "is_instance": True,
+                    })
+                except Exception:
+                    continue
+
+            # Collect type parameters
+            try:
+                type_id = elem.GetTypeId()
+                if type_id and type_id != DB.ElementId.InvalidElementId:
+                    elem_type = doc.GetElement(type_id)
+                    if elem_type:
+                        for param in elem_type.GetOrderedParameters():
+                            try:
+                                param_name = _safe_str(param.Definition.Name)
+                                if param_name in seen_names:
+                                    continue
+                                seen_names.add(param_name)
+
+                                parameters.append({
+                                    "name": param_name,
+                                    "value": _safe_str(_get_param_value_display(param, doc)),
+                                    "storage_type": str(param.StorageType),
+                                    "read_only": param.IsReadOnly,
+                                    "group": _safe_str(_get_param_group_name(param)),
+                                    "is_instance": False,
+                                })
+                            except Exception:
+                                continue
+            except Exception:
+                pass
+
+            return routes.make_response(
+                data={
+                    "status": "success",
+                    "element_id": int(element_id),
+                    "category": category,
+                    "family": family,
+                    "type": type_name,
+                    "parameters": parameters,
+                    "parameter_count": len(parameters),
+                    "message": "Found {} parameters on element {}".format(
+                        len(parameters), element_id
+                    ),
+                }
+            )
+
+        except Exception as e:
+            logger.error("Failed to get element properties: {}".format(str(e)))
+            error_trace = traceback.format_exc()
+            return routes.make_response(
+                data={"error": str(e), "traceback": error_trace}, status=500
+            )
+
+    @api.route("/set_parameter/", methods=["POST"])
+    def set_parameter_handler(doc, request):
+        """Set a single parameter value on an element."""
+        try:
+            if not doc:
+                return routes.make_response(
+                    data={"error": "No active Revit document"}, status=503
+                )
+
+            data = json.loads(request.data) if isinstance(request.data, str) else request.data
+
+            element_id = data.get("element_id")
+            parameter_name = data.get("parameter_name")
+            value = data.get("value")
+
+            if element_id is None:
+                return routes.make_response(
+                    data={"error": "element_id is required"}, status=400
+                )
+            if not parameter_name:
+                return routes.make_response(
+                    data={"error": "parameter_name is required"}, status=400
+                )
+            if value is None:
+                return routes.make_response(
+                    data={"error": "value is required"}, status=400
+                )
+
+            elem_id = make_element_id(element_id)
+            elem = doc.GetElement(elem_id)
+            if not elem:
+                return routes.make_response(
+                    data={"error": "Element {} not found".format(element_id)},
+                    status=404,
+                )
+
+            # Find the parameter
+            param = elem.LookupParameter(parameter_name)
+            if not param:
+                # Try type parameters
+                type_id = elem.GetTypeId()
+                if type_id and type_id != DB.ElementId.InvalidElementId:
+                    elem_type = doc.GetElement(type_id)
+                    if elem_type:
+                        param = elem_type.LookupParameter(parameter_name)
+
+            if not param:
+                available = []
+                for p in elem.Parameters:
+                    try:
+                        available.append(p.Definition.Name)
+                    except Exception:
+                        continue
+                available.sort()
+                return routes.make_response(
+                    data={
+                        "error": "Parameter '{}' not found on element {}".format(
+                            parameter_name, element_id
+                        ),
+                        "available_parameters": available[:30],
+                    },
+                    status=404,
+                )
+
+            if param.IsReadOnly:
+                return routes.make_response(
+                    data={"error": "Parameter '{}' is read-only and cannot be modified.".format(parameter_name)},
+                    status=500,
+                )
+
+            # Get old value
+            old_value = _get_param_value_display(param, doc)
+
+            t = DB.Transaction(doc, "Set Parameter via MCP")
+            t.Start()
+
+            try:
+                # Set value based on storage type
+                if param.StorageType == DB.StorageType.String:
+                    param.Set(str(value))
+                elif param.StorageType == DB.StorageType.Integer:
+                    param.Set(int(value))
+                elif param.StorageType == DB.StorageType.Double:
+                    param.Set(float(value))
+                elif param.StorageType == DB.StorageType.ElementId:
+                    param.Set(make_element_id(value))
+
+                t.Commit()
+
+                new_value = _get_param_value_display(param, doc)
+
+                return routes.make_response(
+                    data={
+                        "status": "success",
+                        "element_id": int(element_id),
+                        "parameter_name": parameter_name,
+                        "old_value": old_value,
+                        "new_value": str(value),
+                        "message": "Set '{}' from '{}' to '{}' on element {}".format(
+                            parameter_name, old_value, value, element_id
+                        ),
+                    }
+                )
+
+            except Exception as tx_error:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                raise tx_error
+
+        except Exception as e:
+            logger.error("Failed to set parameter: {}".format(str(e)))
+            error_trace = traceback.format_exc()
+            return routes.make_response(
+                data={"error": str(e), "traceback": error_trace}, status=500
+            )
+
+    logger.info("Parameter routes registered successfully")

--- a/revit_mcp/ported_annotation.py
+++ b/revit_mcp/ported_annotation.py
@@ -1,0 +1,171 @@
+# -*- coding: UTF-8 -*-
+"""
+Ported from the mcp-servers-for-revit C# command set (CreateDimension, CreateLevel,
+ExportRoomData, SayHello). Reimplemented natively against the pyRevit routes API.
+Units are FEET (the C# originals used mm; converted to feet to match this extension).
+"""
+
+from utils import get_element_name, element_id_value
+from pyrevit import routes, DB
+import json
+import traceback
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _parse(request):
+    if not request or not request.data:
+        return {}
+    return json.loads(request.data) if isinstance(request.data, str) else request.data
+
+
+def _view(doc, name, vid):
+    if vid and int(vid) > 0:
+        el = doc.GetElement(DB.ElementId(int(vid)))
+        if isinstance(el, DB.View):
+            return el
+    if name:
+        for v in DB.FilteredElementCollector(doc).OfClass(DB.View).ToElements():
+            if not v.IsTemplate and get_element_name(v) == name:
+                return v
+    return doc.ActiveView
+
+
+def register_ported_annotation_routes(api):
+
+    @api.route("/create_dimensions/", methods=["POST"])
+    def create_dimensions(doc, request):
+        """
+        Create linear dimensions referencing elements (e.g. grids).
+        Body: {"view_name":"2 - Level 2",  (or "view_id":int)
+               "dimensions":[{"element_ids":[111,222,...],
+                              "line":{"p0":{"x":..,"y":..,"z":0},"p1":{"x":..,"y":..,"z":0}}}]}
+        The dimension line is placed along p0->p1; references come from element_ids
+        (grids and datum elements work directly). Feet.
+        """
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active document"}, status=503)
+            b = _parse(request)
+            dims = b.get("dimensions")
+            if not dims and b.get("element_ids"):
+                dims = [{"element_ids": b.get("element_ids"), "line": b.get("line")}]
+            if not dims:
+                return routes.make_response(data={"error": "No 'dimensions' provided"}, status=400)
+            view = _view(doc, b.get("view_name"), b.get("view_id"))
+            t = DB.Transaction(doc, "MCP Create Dimensions")
+            t.Start()
+            made = []
+            errs = []
+            try:
+                for di in dims:
+                    try:
+                        ln = di.get("line") or {}
+                        p0 = ln.get("p0", {})
+                        p1 = ln.get("p1", {})
+                        a = DB.XYZ(float(p0.get("x", 0)), float(p0.get("y", 0)), float(p0.get("z", 0)))
+                        c = DB.XYZ(float(p1.get("x", 0)), float(p1.get("y", 0)), float(p1.get("z", 0)))
+                        refs = DB.ReferenceArray()
+                        for eid in di.get("element_ids", []):
+                            el = doc.GetElement(DB.ElementId(int(eid)))
+                            if el is None:
+                                continue
+                            try:
+                                refs.Append(DB.Reference(el))
+                            except Exception:
+                                # datum elements (grids/levels) expose .Curve based refs
+                                cur = getattr(el, "Curve", None)
+                                if cur is not None and hasattr(cur, "Reference") and cur.Reference:
+                                    refs.Append(cur.Reference)
+                        if refs.Size < 2:
+                            errs.append("need >=2 valid references")
+                            continue
+                        dim = doc.Create.NewDimension(view, DB.Line.CreateBound(a, c), refs)
+                        made.append(element_id_value(dim.Id))
+                    except Exception as de:
+                        errs.append(str(de))
+                t.Commit()
+            except Exception as tx:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                raise tx
+            return routes.make_response(data={"status": "success", "created": made, "errors": errs[:10]})
+        except Exception as e:
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    @api.route("/create_levels/", methods=["POST"])
+    def create_levels(doc, request):
+        """Create new levels. Body: {"levels":[{"name":"3rd Level","elevation":31.33}]} (feet)."""
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active document"}, status=503)
+            specs = _parse(request).get("levels") or []
+            if not specs:
+                return routes.make_response(data={"error": "No 'levels' provided"}, status=400)
+            t = DB.Transaction(doc, "MCP Create Levels")
+            t.Start()
+            made = []
+            errs = []
+            try:
+                for s in specs:
+                    lvl = DB.Level.Create(doc, float(s.get("elevation", 0)))
+                    if s.get("name"):
+                        try:
+                            lvl.Name = s["name"]
+                        except Exception as ne:
+                            errs.append("name '%s': %s" % (s.get("name"), ne))
+                    made.append({"id": element_id_value(lvl.Id), "name": get_element_name(lvl),
+                                 "elevation": round(lvl.Elevation, 4)})
+                t.Commit()
+            except Exception as tx:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                raise tx
+            return routes.make_response(data={"status": "success", "created": made, "errors": errs[:10]})
+        except Exception as e:
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    @api.route("/export_room_data/", methods=["GET"])
+    def export_room_data(doc):
+        """Export all rooms with key data (name, number, area, level, perimeter, comments)."""
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active document"}, status=503)
+            rooms = (DB.FilteredElementCollector(doc)
+                     .OfCategory(DB.BuiltInCategory.OST_Rooms)
+                     .WhereElementIsNotElementType().ToElements())
+            out = []
+            for r in rooms:
+                def gv(bip):
+                    p = r.get_Parameter(bip)
+                    return p.AsString() if p else None
+                area = r.get_Parameter(DB.BuiltInParameter.ROOM_AREA)
+                out.append({
+                    "id": element_id_value(r.Id),
+                    "name": gv(DB.BuiltInParameter.ROOM_NAME),
+                    "number": gv(DB.BuiltInParameter.ROOM_NUMBER),
+                    "area_sf": round(area.AsDouble(), 2) if area else None,
+                    "level": get_element_name(doc.GetElement(r.LevelId)) if r.LevelId and r.LevelId.IntegerValue > 0 else None,
+                    "comments": gv(DB.BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS),
+                })
+            return routes.make_response(data={"status": "success", "count": len(out), "rooms": out})
+        except Exception as e:
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    @api.route("/say_hello/", methods=["GET"])
+    def say_hello(doc):
+        """Connection test: returns a greeting + basic document info (no modal dialog)."""
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active document"}, status=503)
+            return routes.make_response(data={
+                "status": "success",
+                "message": "Hello from the Revit MCP (Python) — connection OK.",
+                "document": doc.Title,
+                "active_view": get_element_name(doc.ActiveView),
+            })
+        except Exception as e:
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    logger.info("Ported annotation/misc routes registered successfully")

--- a/revit_mcp/ported_create.py
+++ b/revit_mcp/ported_create.py
@@ -1,0 +1,233 @@
+# -*- coding: UTF-8 -*-
+"""
+Ported Creation Routes for Revit MCP (from tools/create_*.ts).
+Implemented against the pyRevit routes API. Units are in FEET (Revit internal),
+not mm as in the original TypeScript tools.
+
+Ports: create_point_based_element, create_line_based_element,
+       create_surface_based_element (floors), create_room
+"""
+
+from utils import get_element_name, find_family_symbol_safely, element_id_value
+from pyrevit import routes, DB
+import json
+import traceback
+import logging
+
+logger = logging.getLogger(__name__)
+ST = DB.Structure.StructuralType
+
+
+def _parse(request):
+    if not request or not request.data:
+        return {}
+    return json.loads(request.data) if isinstance(request.data, str) else request.data
+
+
+def _level_by_name(doc, name):
+    for l in (DB.FilteredElementCollector(doc).OfCategory(DB.BuiltInCategory.OST_Levels)
+              .WhereElementIsNotElementType().ToElements()):
+        if get_element_name(l) == name:
+            return l
+    return None
+
+
+def _level_nearest(doc, z):
+    best = None
+    bd = 1e9
+    for l in (DB.FilteredElementCollector(doc).OfCategory(DB.BuiltInCategory.OST_Levels)
+              .WhereElementIsNotElementType().ToElements()):
+        d = abs(l.Elevation - z)
+        if d < bd:
+            bd = d
+            best = l
+    return best
+
+
+def _resolve_type(doc, item):
+    """Resolve a type from 'typeId' (int) or 'family'+'type' names."""
+    if item.get("typeId") is not None:
+        el = doc.GetElement(DB.ElementId(int(item["typeId"])))
+        return el
+    if item.get("family") and item.get("type"):
+        return find_family_symbol_safely(doc, item["family"], item["type"])
+    return None
+
+
+def register_ported_create_routes(api):
+
+    @api.route("/create_point_based_element/", methods=["POST"])
+    def create_point_based_element(doc, request):
+        """Batch-create point-based family instances. data:[{family,type|typeId,
+        locationPoint:{x,y,z}, level?, rotation?}] (feet, degrees)."""
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active document"}, status=503)
+            items = _parse(request).get("data") or []
+            if not items:
+                return routes.make_response(data={"error": "No 'data' provided"}, status=400)
+            t = DB.Transaction(doc, "MCP Create Point Elements")
+            t.Start()
+            made = []
+            errs = []
+            try:
+                for it in items:
+                    sym = _resolve_type(doc, it)
+                    if not sym or not isinstance(sym, DB.FamilySymbol):
+                        errs.append("type not found for %s" % it.get("name"))
+                        continue
+                    if not sym.IsActive:
+                        sym.Activate()
+                        doc.Regenerate()
+                    lp = it.get("locationPoint", {})
+                    pt = DB.XYZ(float(lp.get("x", 0)), float(lp.get("y", 0)), float(lp.get("z", 0)))
+                    lvl = _level_by_name(doc, it.get("level")) or _level_nearest(doc, pt.Z)
+                    inst = doc.Create.NewFamilyInstance(pt, sym, lvl, ST.NonStructural)
+                    if it.get("rotation"):
+                        ax = DB.Line.CreateBound(pt, pt.Add(DB.XYZ(0, 0, 1)))
+                        inst.Location.Rotate(ax, float(it["rotation"]) * 3.14159265 / 180.0)
+                    made.append(element_id_value(inst.Id))
+                t.Commit()
+            except Exception as tx:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                raise tx
+            return routes.make_response(data={"status": "success", "created": made, "errors": errs[:10]})
+        except Exception as e:
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    @api.route("/create_line_based_element/", methods=["POST"])
+    def create_line_based_element(doc, request):
+        """Batch-create line-based elements (walls or structural framing).
+        data:[{family,type|typeId, locationLine:{p0:{x,y,z},p1:{x,y,z}},
+        height?, baseLevel?, baseOffset?, level?}] (feet). Walls use WallType; framing uses a FamilySymbol."""
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active document"}, status=503)
+            items = _parse(request).get("data") or []
+            if not items:
+                return routes.make_response(data={"error": "No 'data' provided"}, status=400)
+            t = DB.Transaction(doc, "MCP Create Line Elements")
+            t.Start()
+            made = []
+            errs = []
+            try:
+                for it in items:
+                    ll = it.get("locationLine", {})
+                    p0 = ll.get("p0", {})
+                    p1 = ll.get("p1", {})
+                    a = DB.XYZ(float(p0.get("x", 0)), float(p0.get("y", 0)), float(p0.get("z", 0)))
+                    b = DB.XYZ(float(p1.get("x", 0)), float(p1.get("y", 0)), float(p1.get("z", 0)))
+                    if a.DistanceTo(b) < 0.1:
+                        errs.append("degenerate %s" % it.get("name"))
+                        continue
+                    line = DB.Line.CreateBound(a, b)
+                    et = _resolve_type(doc, it)
+                    lvl = _level_by_name(doc, it.get("level")) or _level_nearest(doc, a.Z)
+                    if isinstance(et, DB.WallType):
+                        h = float(it.get("height", 10.0))
+                        off = float(it.get("baseOffset", 0.0))
+                        w = DB.Wall.Create(doc, line, et.Id, lvl.Id, h, off, False, False)
+                        made.append(element_id_value(w.Id))
+                    elif isinstance(et, DB.FamilySymbol):
+                        if not et.IsActive:
+                            et.Activate()
+                            doc.Regenerate()
+                        inst = doc.Create.NewFamilyInstance(line, et, lvl, ST.Beam)
+                        made.append(element_id_value(inst.Id))
+                    else:
+                        errs.append("type not found for %s" % it.get("name"))
+                t.Commit()
+            except Exception as tx:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                raise tx
+            return routes.make_response(data={"status": "success", "created": made, "errors": errs[:10]})
+        except Exception as e:
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    @api.route("/create_surface_based_element/", methods=["POST"])
+    def create_surface_based_element(doc, request):
+        """Batch-create floors from boundary loops. data:[{family,type|typeId,
+        boundary:{outerLoop:[{p0,p1},...]}, level?, baseOffset?}] (feet)."""
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active document"}, status=503)
+            items = _parse(request).get("data") or []
+            if not items:
+                return routes.make_response(data={"error": "No 'data' provided"}, status=400)
+            from System.Collections.Generic import List
+            t = DB.Transaction(doc, "MCP Create Floors")
+            t.Start()
+            made = []
+            errs = []
+            try:
+                for it in items:
+                    seg = (it.get("boundary", {}) or {}).get("outerLoop") or []
+                    if len(seg) < 3:
+                        errs.append("need >=3 boundary segments for %s" % it.get("name"))
+                        continue
+                    loop = DB.CurveLoop()
+                    for s in seg:
+                        p0 = s["p0"]
+                        p1 = s["p1"]
+                        loop.Append(DB.Line.CreateBound(
+                            DB.XYZ(float(p0["x"]), float(p0["y"]), float(p0["z"])),
+                            DB.XYZ(float(p1["x"]), float(p1["y"]), float(p1["z"]))))
+                    ft = _resolve_type(doc, it)
+                    if not ft:
+                        ft = doc.GetElement(DB.FilteredElementCollector(doc)
+                                            .OfClass(DB.FloorType).FirstElementId())
+                    lvl = _level_by_name(doc, it.get("level")) or _level_nearest(doc, float(seg[0]["p0"]["z"]))
+                    loops = List[DB.CurveLoop]()
+                    loops.Add(loop)
+                    fl = DB.Floor.Create(doc, loops, ft.Id, lvl.Id)
+                    if it.get("baseOffset"):
+                        pp = fl.get_Parameter(DB.BuiltInParameter.FLOOR_HEIGHTABOVELEVEL_PARAM)
+                        if pp:
+                            pp.Set(float(it["baseOffset"]))
+                    made.append(element_id_value(fl.Id))
+                t.Commit()
+            except Exception as tx:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                raise tx
+            return routes.make_response(data={"status": "success", "created": made, "errors": errs[:10]})
+        except Exception as e:
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    @api.route("/create_room/", methods=["POST"])
+    def create_room(doc, request):
+        """Create rooms at points. data:[{level, x, y, name?, number?}] (feet)."""
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active document"}, status=503)
+            items = _parse(request).get("data") or _parse(request).get("rooms") or []
+            if not items:
+                return routes.make_response(data={"error": "No room data provided"}, status=400)
+            t = DB.Transaction(doc, "MCP Create Rooms")
+            t.Start()
+            made = []
+            errs = []
+            try:
+                for it in items:
+                    lvl = _level_by_name(doc, it.get("level"))
+                    if not lvl:
+                        errs.append("level not found: %s" % it.get("level"))
+                        continue
+                    rm = doc.Create.NewRoom(lvl, DB.UV(float(it.get("x", 0)), float(it.get("y", 0))))
+                    if it.get("name"):
+                        rm.get_Parameter(DB.BuiltInParameter.ROOM_NAME).Set(str(it["name"]))
+                    if it.get("number"):
+                        rm.get_Parameter(DB.BuiltInParameter.ROOM_NUMBER).Set(str(it["number"]))
+                    made.append(element_id_value(rm.Id))
+                t.Commit()
+            except Exception as tx:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                raise tx
+            return routes.make_response(data={"status": "success", "created": made, "errors": errs[:10]})
+        except Exception as e:
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    logger.info("Ported create routes registered successfully")

--- a/revit_mcp/ported_ops.py
+++ b/revit_mcp/ported_ops.py
@@ -1,0 +1,238 @@
+# -*- coding: UTF-8 -*-
+"""
+Ported Operations Routes for Revit MCP (from tools/operate_element.ts, tag_all_rooms.ts,
+analyze_model_statistics.ts, ai_element_filter.ts) + a smart schedule generator.
+"""
+
+from utils import get_element_name, element_id_value
+from pyrevit import routes, revit, DB
+import json
+import traceback
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _parse(request):
+    if not request or not request.data:
+        return {}
+    return json.loads(request.data) if isinstance(request.data, str) else request.data
+
+
+def _ids(doc, id_list):
+    from System.Collections.Generic import List
+    return List[DB.ElementId]([DB.ElementId(int(i)) for i in id_list])
+
+
+def _cat_id(doc, name):
+    key = name if name.startswith("OST_") else "OST_" + name.replace(" ", "")
+    bic = getattr(DB.BuiltInCategory, key, None)
+    return DB.ElementId(bic) if bic is not None else None
+
+
+def register_ported_ops_routes(api):
+
+    @api.route("/operate_element/", methods=["POST"])
+    def operate_element(doc, request):
+        """Operate on elements. Body: {"elementIds":[..], "action":"Select|Hide|Unhide|
+        Isolate|ResetIsolate|SetColor|SetTransparency|Delete|Highlight",
+        "colorValue":[r,g,b], "transparencyValue":0-100}."""
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active document"}, status=503)
+            b = _parse(request)
+            action = (b.get("action") or "").lower()
+            ids = b.get("elementIds") or []
+            view = doc.ActiveView
+            if action == "select":
+                revit.uidoc.Selection.SetElementIds(_ids(doc, ids))
+                return routes.make_response(data={"status": "success", "action": "Select", "count": len(ids)})
+            t = DB.Transaction(doc, "MCP Operate Elements")
+            t.Start()
+            try:
+                if action in ("hide",):
+                    view.HideElements(_ids(doc, ids))
+                elif action == "unhide":
+                    view.UnhideElements(_ids(doc, ids))
+                elif action == "isolate":
+                    view.IsolateElementsTemporary(_ids(doc, ids))
+                elif action == "resetisolate":
+                    view.DisableTemporaryViewMode(DB.TemporaryViewMode.TemporaryHideIsolate)
+                elif action == "delete":
+                    doc.Delete(_ids(doc, ids))
+                elif action in ("setcolor", "highlight", "settransparency"):
+                    ogs = DB.OverrideGraphicSettings()
+                    if action in ("setcolor", "highlight"):
+                        rgb = b.get("colorValue", [255, 0, 0]) if action == "setcolor" else [255, 0, 0]
+                        col = DB.Color(int(rgb[0]), int(rgb[1]), int(rgb[2]))
+                        ogs.SetProjectionLineColor(col)
+                        ogs.SetSurfaceForegroundPatternColor(col)
+                        sfp = DB.FilteredElementCollector(doc).OfClass(DB.FillPatternElement).FirstElement()
+                        if sfp:
+                            ogs.SetSurfaceForegroundPatternId(sfp.Id)
+                    if action == "settransparency":
+                        ogs.SetSurfaceTransparency(int(b.get("transparencyValue", 50)))
+                    for i in ids:
+                        view.SetElementOverrides(DB.ElementId(int(i)), ogs)
+                else:
+                    t.RollBack()
+                    return routes.make_response(data={"error": "unsupported action: %s" % action}, status=400)
+                t.Commit()
+            except Exception as tx:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                raise tx
+            return routes.make_response(data={"status": "success", "action": action, "count": len(ids)})
+        except Exception as e:
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    @api.route("/tag_all_rooms/", methods=["POST"])
+    def tag_all_rooms(doc, request):
+        """Tag all rooms in the active view at their centers."""
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active document"}, status=503)
+            use_leader = bool(_parse(request).get("useLeader", False))
+            view = doc.ActiveView
+            rooms = list(DB.FilteredElementCollector(doc, view.Id)
+                         .OfCategory(DB.BuiltInCategory.OST_Rooms).WhereElementIsNotElementType())
+            t = DB.Transaction(doc, "MCP Tag Rooms")
+            t.Start()
+            n = 0
+            try:
+                for r in rooms:
+                    try:
+                        loc = r.Location
+                        pt = loc.Point if hasattr(loc, "Point") else None
+                        if pt is None:
+                            continue
+                        uv = DB.UV(pt.X, pt.Y)
+                        DB.RoomTag  # ensure available
+                        doc.Create.NewRoomTag(DB.LinkElementId(r.Id), uv, view.Id)
+                        n += 1
+                    except Exception:
+                        continue
+                t.Commit()
+            except Exception as tx:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                raise tx
+            return routes.make_response(data={"status": "success", "tagged": n, "rooms": len(rooms)})
+        except Exception as e:
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    @api.route("/analyze_model_statistics/", methods=["GET"])
+    def analyze_model_statistics(doc):
+        """Model statistics: element counts by category, totals."""
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active document"}, status=503)
+            from collections import Counter
+            cats = Counter()
+            total = 0
+            for e in DB.FilteredElementCollector(doc).WhereElementIsNotElementType():
+                try:
+                    if e.Category:
+                        cats[e.Category.Name] += 1
+                        total += 1
+                except Exception:
+                    continue
+            types = DB.FilteredElementCollector(doc).WhereElementIsElementType().GetElementCount()
+            top = dict(sorted(cats.items(), key=lambda kv: -kv[1])[:40])
+            return routes.make_response(data={"status": "success", "total_instances": total,
+                                              "total_types": types, "by_category": top})
+        except Exception as e:
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    @api.route("/ai_element_filter/", methods=["POST"])
+    def ai_element_filter(doc, request):
+        """Filter elements by criteria. Body: {"category":"OST_StructuralFraming",
+        "parameter":"Generic Size","operator":"contains|equals|gt|lt","value":"W16"}.
+        Returns matching element ids (+ values)."""
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active document"}, status=503)
+            b = _parse(request)
+            col = DB.FilteredElementCollector(doc).WhereElementIsNotElementType()
+            cid = _cat_id(doc, b.get("category", "")) if b.get("category") else None
+            if cid is not None:
+                col = col.OfCategoryId(cid)
+            pname = b.get("parameter")
+            op = (b.get("operator") or "contains").lower()
+            val = b.get("value")
+            limit = int(b.get("limit", 300))
+            out = []
+            for e in col:
+                if len(out) >= limit:
+                    break
+                if not pname:
+                    out.append({"id": element_id_value(e.Id), "name": get_element_name(e)})
+                    continue
+                p = e.LookupParameter(pname)
+                if not p:
+                    continue
+                if p.StorageType == DB.StorageType.String:
+                    pv = p.AsString() or ""
+                    ok = (val.lower() in pv.lower()) if op == "contains" else (pv == val)
+                else:
+                    try:
+                        pv = p.AsDouble()
+                        fv = float(val)
+                        ok = {"gt": pv > fv, "lt": pv < fv, "equals": abs(pv - fv) < 1e-6}.get(op, False)
+                    except Exception:
+                        ok = False
+                    pv = round(pv, 4) if isinstance(pv, float) else pv
+                if ok:
+                    out.append({"id": element_id_value(e.Id), "name": get_element_name(e), "value": pv})
+            return routes.make_response(data={"status": "success", "count": len(out), "matches": out})
+        except Exception as e:
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    @api.route("/create_schedule/", methods=["POST"])
+    def create_schedule(doc, request):
+        """Create a schedule for a category with chosen fields (incl. KPFF shared params).
+        Body: {"category":"OST_StructuralColumns","name":"STEEL COLUMN SCHEDULE",
+        "fields":["Type","Generic Size","Comments"]}."""
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active document"}, status=503)
+            b = _parse(request)
+            cid = _cat_id(doc, b.get("category", ""))
+            if cid is None:
+                return routes.make_response(data={"error": "invalid category"}, status=400)
+            wanted = b.get("fields") or []
+            t = DB.Transaction(doc, "MCP Create Schedule")
+            t.Start()
+            try:
+                sched = DB.ViewSchedule.CreateSchedule(doc, cid)
+                if b.get("name"):
+                    sched.Name = b["name"]
+                defn = sched.Definition
+                # map available schedulable fields by display name
+                avail = {}
+                for sf in defn.GetSchedulableFields():
+                    try:
+                        avail[sf.GetName(doc)] = sf
+                    except Exception:
+                        continue
+                added = []
+                missing = []
+                for fn in wanted:
+                    sf = avail.get(fn)
+                    if sf:
+                        defn.AddField(sf)
+                        added.append(fn)
+                    else:
+                        missing.append(fn)
+                t.Commit()
+            except Exception as tx:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                raise tx
+            return routes.make_response(data={"status": "success", "schedule_id": element_id_value(sched.Id),
+                                              "name": get_element_name(sched), "fields_added": added,
+                                              "fields_missing": missing})
+        except Exception as e:
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    logger.info("Ported ops routes registered successfully")

--- a/revit_mcp/ported_query.py
+++ b/revit_mcp/ported_query.py
@@ -1,0 +1,293 @@
+# -*- coding: UTF-8 -*-
+"""
+Ported Query/Edit Routes for Revit MCP
+Python implementations of TypeScript tools from tools/*.ts that previously
+forwarded to a separate Revit plugin. Implemented here directly against the
+pyRevit routes API. Lengths are in feet (Revit internal units).
+
+Ports: get_current_view_info, get_selected_elements, get_current_view_elements,
+       get_available_family_types, get_material_quantities, tag_all_walls,
+       delete_elements, modify_element
+"""
+
+from utils import get_element_name, element_id_value
+from pyrevit import routes, revit, DB
+import json
+import traceback
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _parse(request):
+    if not request or not request.data:
+        return {}
+    if isinstance(request.data, str):
+        try:
+            return json.loads(request.data)
+        except Exception:
+            return {}
+    return request.data
+
+
+def _cat_to_bic(name):
+    """Resolve 'OST_Walls' or 'Walls' to a BuiltInCategory, else None."""
+    if not name:
+        return None
+    key = name if name.startswith("OST_") else "OST_" + name.replace(" ", "")
+    return getattr(DB.BuiltInCategory, key, None)
+
+
+def register_ported_query_routes(api):
+
+    @api.route("/get_current_view_info/", methods=["GET"])
+    def get_current_view_info(doc):
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active document"}, status=503)
+            v = doc.ActiveView
+            data = {
+                "name": get_element_name(v),
+                "id": element_id_value(v.Id),
+                "view_type": str(v.ViewType),
+                "scale": getattr(v, "Scale", None),
+                "detail_level": str(v.DetailLevel) if hasattr(v, "DetailLevel") else None,
+                "is_template": v.IsTemplate,
+            }
+            try:
+                if v.GenLevel:
+                    data["level"] = get_element_name(v.GenLevel)
+            except Exception:
+                pass
+            return routes.make_response(data={"status": "success", "view": data})
+        except Exception as e:
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    @api.route("/get_selected_elements/", methods=["POST"])
+    def get_selected_elements(doc, request):
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active document"}, status=503)
+            limit = int(_parse(request).get("limit", 100))
+            ids = list(revit.uidoc.Selection.GetElementIds())
+            out = []
+            for eid in ids[:limit]:
+                e = doc.GetElement(eid)
+                if not e:
+                    continue
+                out.append({
+                    "id": element_id_value(eid),
+                    "name": get_element_name(e),
+                    "category": e.Category.Name if e.Category else None,
+                    "type": (get_element_name(doc.GetElement(e.GetTypeId()))
+                             if e.GetTypeId() and e.GetTypeId().IntegerValue > 0 else None),
+                })
+            return routes.make_response(data={"status": "success", "count": len(out),
+                                              "total_selected": len(ids), "elements": out})
+        except Exception as e:
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    @api.route("/get_current_view_elements/", methods=["POST"])
+    def get_current_view_elements(doc, request):
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active document"}, status=503)
+            body = _parse(request)
+            limit = int(body.get("limit", 200))
+            col = DB.FilteredElementCollector(doc, doc.ActiveView.Id).WhereElementIsNotElementType()
+            bic = _cat_to_bic(body.get("category"))
+            if bic is not None:
+                col = col.OfCategory(bic)
+            out = []
+            for e in col:
+                if len(out) >= limit:
+                    break
+                out.append({
+                    "id": element_id_value(e.Id),
+                    "name": get_element_name(e),
+                    "category": e.Category.Name if e.Category else None,
+                })
+            return routes.make_response(data={"status": "success", "count": len(out), "elements": out})
+        except Exception as e:
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    @api.route("/get_available_family_types/", methods=["POST"])
+    def get_available_family_types(doc, request):
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active document"}, status=503)
+            body = _parse(request)
+            limit = int(body.get("limit", 200))
+            contains = (body.get("contains") or "").lower()
+            bic = _cat_to_bic(body.get("category"))
+            col = DB.FilteredElementCollector(doc).OfClass(DB.FamilySymbol)
+            if bic is not None:
+                col = col.OfCategory(bic)
+            out = []
+            for s in col:
+                if len(out) >= limit:
+                    break
+                fam = get_element_name(s.Family)
+                typ = get_element_name(s)
+                if contains and contains not in fam.lower() and contains not in typ.lower():
+                    continue
+                out.append({"family": fam, "type": typ,
+                            "category": s.Category.Name if s.Category else None,
+                            "id": element_id_value(s.Id), "is_active": s.IsActive})
+            return routes.make_response(data={"status": "success", "count": len(out), "types": out})
+        except Exception as e:
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    @api.route("/get_material_quantities/", methods=["POST"])
+    def get_material_quantities(doc, request):
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active document"}, status=503)
+            body = _parse(request)
+            cats = body.get("categoryFilters")
+            sel_only = bool(body.get("selectedElementsOnly", False))
+            if sel_only:
+                ids = list(revit.uidoc.Selection.GetElementIds())
+                elements = [doc.GetElement(i) for i in ids]
+            else:
+                elements = list(DB.FilteredElementCollector(doc).WhereElementIsNotElementType())
+            wanted = None
+            if cats:
+                wanted = set([c if c.startswith("OST_") else "OST_" + c.replace(" ", "") for c in cats])
+            mats = {}
+            for e in elements:
+                try:
+                    if wanted is not None:
+                        if not e.Category:
+                            continue
+                        # category enum name
+                        bic = e.Category.Id.IntegerValue
+                        cname = str(DB.Category.GetCategory(doc, e.Category.Id).Name) if e.Category else ""
+                        # match by display name or OST key best-effort
+                        if not any(w.replace("OST_", "").lower() in cname.replace(" ", "").lower() for w in wanted):
+                            continue
+                    for mid in e.GetMaterialIds(False):
+                        m = doc.GetElement(mid)
+                        if not m:
+                            continue
+                        key = get_element_name(m)
+                        rec = mats.setdefault(key, {"material": key, "area_sf": 0.0, "volume_cf": 0.0, "elements": 0})
+                        rec["area_sf"] += e.GetMaterialArea(mid, False)
+                        rec["volume_cf"] += e.GetMaterialVolume(mid)
+                        rec["elements"] += 1
+                except Exception:
+                    continue
+            result = sorted(mats.values(), key=lambda r: -r["volume_cf"])
+            for r in result:
+                r["area_sf"] = round(r["area_sf"], 2)
+                r["volume_cf"] = round(r["volume_cf"], 2)
+            return routes.make_response(data={"status": "success", "materials": result, "count": len(result)})
+        except Exception as e:
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    @api.route("/tag_all_walls/", methods=["POST"])
+    def tag_all_walls(doc, request):
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active document"}, status=503)
+            body = _parse(request)
+            use_leader = bool(body.get("useLeader", False))
+            view = doc.ActiveView
+            walls = list(DB.FilteredElementCollector(doc, view.Id)
+                         .OfCategory(DB.BuiltInCategory.OST_Walls)
+                         .WhereElementIsNotElementType())
+            t = DB.Transaction(doc, "MCP Tag Walls")
+            t.Start()
+            n = 0
+            try:
+                for w in walls:
+                    try:
+                        loc = w.Location
+                        if not isinstance(loc, DB.LocationCurve):
+                            continue
+                        m = loc.Curve.Evaluate(0.5, True)
+                        DB.IndependentTag.Create(
+                            doc, view.Id, DB.Reference(w), use_leader,
+                            DB.TagMode.TM_ADDBY_CATEGORY, DB.TagOrientation.Horizontal,
+                            DB.XYZ(m.X, m.Y, m.Z))
+                        n += 1
+                    except Exception:
+                        continue
+                t.Commit()
+            except Exception as tx:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                raise tx
+            return routes.make_response(data={"status": "success", "tagged": n, "walls": len(walls)})
+        except Exception as e:
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    @api.route("/delete_elements/", methods=["POST"])
+    def delete_elements(doc, request):
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active document"}, status=503)
+            ids = _parse(request).get("element_ids") or []
+            if not ids:
+                return routes.make_response(data={"error": "No element_ids provided"}, status=400)
+            from System.Collections.Generic import List
+            eids = List[DB.ElementId]([DB.ElementId(int(i)) for i in ids])
+            t = DB.Transaction(doc, "MCP Delete Elements")
+            t.Start()
+            try:
+                deleted = doc.Delete(eids)
+                t.Commit()
+            except Exception as tx:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                raise tx
+            return routes.make_response(data={"status": "success", "deleted": len(list(deleted))})
+        except Exception as e:
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    @api.route("/modify_element/", methods=["POST"])
+    def modify_element(doc, request):
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active document"}, status=503)
+            body = _parse(request)
+            eid = body.get("element_id")
+            params = body.get("parameters") or {}
+            if eid is None:
+                return routes.make_response(data={"error": "No element_id provided"}, status=400)
+            e = doc.GetElement(DB.ElementId(int(eid)))
+            if not e:
+                return routes.make_response(data={"error": "Element not found"}, status=404)
+            t = DB.Transaction(doc, "MCP Modify Element")
+            t.Start()
+            done = []
+            failed = []
+            try:
+                for name, value in params.items():
+                    p = e.LookupParameter(name)
+                    if not p or p.IsReadOnly:
+                        failed.append(name)
+                        continue
+                    st = p.StorageType
+                    if st == DB.StorageType.String:
+                        p.Set(str(value))
+                    elif st == DB.StorageType.Integer:
+                        p.Set(int(value))
+                    elif st == DB.StorageType.Double:
+                        p.Set(float(value))
+                    elif st == DB.StorageType.ElementId:
+                        p.Set(DB.ElementId(int(value)))
+                    else:
+                        failed.append(name)
+                        continue
+                    done.append(name)
+                t.Commit()
+            except Exception as tx:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                raise tx
+            return routes.make_response(data={"status": "success", "set": done, "failed": failed})
+        except Exception as e:
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    logger.info("Ported query/edit routes registered successfully")

--- a/revit_mcp/rvt_extras.py
+++ b/revit_mcp/rvt_extras.py
@@ -1,0 +1,283 @@
+# -*- coding: UTF-8 -*-
+"""
+Net-new tools cherry-picked from rvt-mcp (bimwright): QA/lint, organization,
+and view utilities. Reimplemented natively against the pyRevit routes API.
+"""
+
+from utils import get_element_name, element_id_value
+from pyrevit import routes, revit, DB
+import json, re, traceback, logging
+
+logger = logging.getLogger(__name__)
+
+
+def _parse(request):
+    if not request or not request.data:
+        return {}
+    return json.loads(request.data) if isinstance(request.data, str) else request.data
+
+
+def _view(doc, b):
+    if b.get("view_id"):
+        el = doc.GetElement(DB.ElementId(int(b["view_id"])))
+        if isinstance(el, DB.View):
+            return el
+    if b.get("view_name"):
+        for v in DB.FilteredElementCollector(doc).OfClass(DB.View):
+            if not v.IsTemplate and get_element_name(v) == b["view_name"]:
+                return v
+    return doc.ActiveView
+
+
+def _cat_bic(name):
+    key = name if name.startswith("OST_") else "OST_" + name.replace(" ", "")
+    return getattr(DB.BuiltInCategory, key, None)
+
+
+def _err(e):
+    return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+
+def register_rvt_extras_routes(api):
+
+    @api.route("/get_model_warnings/", methods=["GET"])
+    def get_model_warnings(doc):
+        """Summarize all Revit warnings: description + failing element ids, grouped by message."""
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active document"}, status=503)
+            from collections import Counter
+            warns = doc.GetWarnings()
+            groups = Counter()
+            items = []
+            for w in warns:
+                desc = w.GetDescriptionText()
+                groups[desc] += 1
+                ids = [element_id_value(i) for i in w.GetFailingElements()]
+                items.append({"description": desc, "severity": str(w.GetSeverity()), "element_ids": ids})
+            return routes.make_response(data={"status": "success", "total": len(items),
+                                              "by_message": dict(groups.most_common()), "warnings": items[:300]})
+        except Exception as e: return _err(e)
+
+    @api.route("/analyze_view_naming/", methods=["POST"])
+    def analyze_view_naming(doc, request):
+        """Check view names against a regex pattern. Body: {pattern: '^S-..', view_type: 'FloorPlan'(opt)}.
+        Returns matching/non-matching views."""
+        try:
+            b = _parse(request)
+            pat = re.compile(b["pattern"]) if b.get("pattern") else None
+            vt = b.get("view_type")
+            ok, bad = [], []
+            for v in DB.FilteredElementCollector(doc).OfClass(DB.View):
+                if v.IsTemplate:
+                    continue
+                if vt and str(v.ViewType) != vt:
+                    continue
+                nm = get_element_name(v)
+                rec = {"id": element_id_value(v.Id), "name": nm, "type": str(v.ViewType)}
+                if pat is None or pat.search(nm):
+                    ok.append(rec)
+                else:
+                    bad.append(rec)
+            return routes.make_response(data={"status": "success", "compliant": len(ok),
+                                              "noncompliant": len(bad), "noncompliant_views": bad[:200]})
+        except Exception as e: return _err(e)
+
+    @api.route("/find_untagged_elements/", methods=["POST"])
+    def find_untagged_elements(doc, request):
+        """Find elements of a category in a view that have no tag. Body: {category, view_name}."""
+        try:
+            b = _parse(request); view = _view(doc, b)
+            bic = _cat_bic(b.get("category", ""))
+            if bic is None:
+                return routes.make_response(data={"error": "valid 'category' required"}, status=400)
+            tagged = set()
+            for t in DB.FilteredElementCollector(doc, view.Id).OfClass(DB.IndependentTag):
+                try:
+                    for r in t.GetTaggedLocalElementIds():
+                        tagged.add(r.IntegerValue)
+                except Exception:
+                    try: tagged.add(t.TaggedLocalElementId.IntegerValue)
+                    except Exception: pass
+            untagged = []
+            for e in DB.FilteredElementCollector(doc, view.Id).OfCategory(bic).WhereElementIsNotElementType():
+                if element_id_value(e.Id) not in tagged:
+                    untagged.append({"id": element_id_value(e.Id), "name": get_element_name(e)})
+            return routes.make_response(data={"status": "success", "untagged_count": len(untagged),
+                                              "untagged": untagged[:300]})
+        except Exception as e: return _err(e)
+
+    @api.route("/cleanup_empty_tags/", methods=["POST"])
+    def cleanup_empty_tags(doc, request):
+        """Delete tags with empty text in a view (or whole model if all_views=true). Body: {view_name, all_views:false}."""
+        try:
+            b = _parse(request)
+            col = (DB.FilteredElementCollector(doc).OfClass(DB.IndependentTag) if b.get("all_views")
+                   else DB.FilteredElementCollector(doc, _view(doc, b).Id).OfClass(DB.IndependentTag))
+            victims = []
+            for t in col:
+                try:
+                    txt = t.TagText
+                except Exception:
+                    txt = None
+                if txt is None or not str(txt).strip():
+                    victims.append(t.Id)
+            t0 = DB.Transaction(doc, "Cleanup Empty Tags"); t0.Start()
+            n = 0
+            try:
+                for vid in victims:
+                    doc.Delete(vid); n += 1
+                t0.Commit()
+            except Exception as tx:
+                if t0.HasStarted() and not t0.HasEnded(): t0.RollBack()
+                raise tx
+            return routes.make_response(data={"status": "success", "deleted": n})
+        except Exception as e: return _err(e)
+
+    @api.route("/create_group/", methods=["POST"])
+    def create_group(doc, request):
+        """Create a model group from elements. Body: {element_ids:[...], name:'...'}."""
+        try:
+            b = _parse(request)
+            from System.Collections.Generic import List
+            ids = List[DB.ElementId]([DB.ElementId(int(i)) for i in b.get("element_ids", [])])
+            if ids.Count == 0:
+                return routes.make_response(data={"error": "element_ids required"}, status=400)
+            t = DB.Transaction(doc, "Create Group"); t.Start()
+            try:
+                g = doc.Create.NewGroup(ids)
+                if b.get("name"):
+                    try: g.GroupType.Name = b["name"]
+                    except Exception: pass
+                t.Commit()
+            except Exception as tx:
+                if t.HasStarted() and not t.HasEnded(): t.RollBack()
+                raise tx
+            return routes.make_response(data={"status": "success", "group_id": element_id_value(g.Id),
+                                              "name": get_element_name(g.GroupType)})
+        except Exception as e: return _err(e)
+
+    @api.route("/purge_unused_families/", methods=["POST"])
+    def purge_unused_families(doc, request):
+        """Delete loadable families that have zero placed instances. Body: {dry_run:true} to only report."""
+        try:
+            b = _parse(request); dry = bool(b.get("dry_run", True))
+            # count instances per family symbol
+            used = set()
+            for fi in DB.FilteredElementCollector(doc).OfClass(DB.FamilyInstance).WhereElementIsNotElementType():
+                try: used.add(fi.Symbol.Family.Id.IntegerValue)
+                except Exception: pass
+            victims = []
+            for fam in DB.FilteredElementCollector(doc).OfClass(DB.Family):
+                if fam.Id.IntegerValue not in used and fam.IsEditable:
+                    victims.append((fam.Id, get_element_name(fam)))
+            names = [v[1] for v in victims]
+            if dry:
+                return routes.make_response(data={"status": "success", "dry_run": True,
+                                                  "unused_count": len(victims), "unused_families": names[:300]})
+            t = DB.Transaction(doc, "Purge Unused Families"); t.Start(); n = 0
+            try:
+                for fid, _ in victims:
+                    try: doc.Delete(fid); n += 1
+                    except Exception: pass
+                t.Commit()
+            except Exception as tx:
+                if t.HasStarted() and not t.HasEnded(): t.RollBack()
+                raise tx
+            return routes.make_response(data={"status": "success", "deleted": n, "families": names[:300]})
+        except Exception as e: return _err(e)
+
+    @api.route("/set_project_info/", methods=["POST"])
+    def set_project_info(doc, request):
+        """Set Project Information parameters. Body: {params:{'Project Name':'...','Project Number':'...'}}."""
+        try:
+            b = _parse(request); params = b.get("params") or {}
+            pi = doc.ProjectInformation
+            t = DB.Transaction(doc, "Set Project Info"); t.Start()
+            done, failed = [], []
+            try:
+                for k, v in params.items():
+                    p = pi.LookupParameter(k)
+                    if p and not p.IsReadOnly and p.StorageType == DB.StorageType.String:
+                        p.Set(str(v)); done.append(k)
+                    else:
+                        failed.append(k)
+                t.Commit()
+            except Exception as tx:
+                if t.HasStarted() and not t.HasEnded(): t.RollBack()
+                raise tx
+            return routes.make_response(data={"status": "success", "set": done, "failed": failed})
+        except Exception as e: return _err(e)
+
+    @api.route("/set_view_crop_scale/", methods=["POST"])
+    def set_view_crop_scale(doc, request):
+        """Set a view's scale and/or crop. Body: {view_name, scale:48, crop_active:true}."""
+        try:
+            b = _parse(request); view = _view(doc, b)
+            t = DB.Transaction(doc, "Set View Crop/Scale"); t.Start()
+            try:
+                if b.get("scale") is not None:
+                    view.Scale = int(b["scale"])
+                if b.get("crop_active") is not None:
+                    view.CropBoxActive = bool(b["crop_active"])
+                    view.CropBoxVisible = bool(b["crop_active"])
+                t.Commit()
+            except Exception as tx:
+                if t.HasStarted() and not t.HasEnded(): t.RollBack()
+                raise tx
+            return routes.make_response(data={"status": "success", "view": get_element_name(view),
+                                              "scale": view.Scale, "crop_active": view.CropBoxActive})
+        except Exception as e: return _err(e)
+
+    @api.route("/show_element/", methods=["POST"])
+    def show_element(doc, request):
+        """Select and zoom to elements in the UI. Body: {element_ids:[...]}."""
+        try:
+            b = _parse(request)
+            from System.Collections.Generic import List
+            ids = List[DB.ElementId]([DB.ElementId(int(i)) for i in b.get("element_ids", [])])
+            if ids.Count == 0:
+                return routes.make_response(data={"error": "element_ids required"}, status=400)
+            revit.uidoc.Selection.SetElementIds(ids)
+            try: revit.uidoc.ShowElements(ids)
+            except Exception: pass
+            return routes.make_response(data={"status": "success", "shown": ids.Count})
+        except Exception as e: return _err(e)
+
+    @api.route("/create_callout/", methods=["POST"])
+    def create_callout(doc, request):
+        """Create a callout on a parent view. Body: {parent_view_name|parent_view_id,
+        p1:{x,y}, p2:{x,y}}  (feet). Uses a Detail callout view family type."""
+        try:
+            b = _parse(request)
+            pv = None
+            if b.get("parent_view_id"):
+                el = doc.GetElement(DB.ElementId(int(b["parent_view_id"])))
+                pv = el if isinstance(el, DB.View) else None
+            elif b.get("parent_view_name"):
+                for v in DB.FilteredElementCollector(doc).OfClass(DB.View):
+                    if not v.IsTemplate and get_element_name(v) == b["parent_view_name"]:
+                        pv = v; break
+            if pv is None:
+                pv = doc.ActiveView
+            vft = None
+            for v in DB.FilteredElementCollector(doc).OfClass(DB.ViewFamilyType):
+                if v.ViewFamily == DB.ViewFamily.Detail:
+                    vft = v; break
+            if vft is None:
+                return routes.make_response(data={"error": "no Detail view family type"}, status=404)
+            p1 = b.get("p1", {}); p2 = b.get("p2", {})
+            a = DB.XYZ(float(p1.get("x", 0)), float(p1.get("y", 0)), 0)
+            c = DB.XYZ(float(p2.get("x", 10)), float(p2.get("y", 10)), 0)
+            t = DB.Transaction(doc, "Create Callout"); t.Start()
+            try:
+                cv = DB.ViewSection.CreateCallout(doc, pv.Id, vft.Id, a, c)
+                t.Commit()
+            except Exception as tx:
+                if t.HasStarted() and not t.HasEnded(): t.RollBack()
+                raise tx
+            return routes.make_response(data={"status": "success", "callout_view_id": element_id_value(cv.Id),
+                                              "parent_view": get_element_name(pv)})
+        except Exception as e: return _err(e)
+
+    logger.info("rvt-mcp extras routes registered successfully")

--- a/revit_mcp/shared_params.py
+++ b/revit_mcp/shared_params.py
@@ -1,0 +1,426 @@
+# -*- coding: UTF-8 -*-
+"""
+Shared-parameter, reference-plane, and graphic-override routes.
+Ported from the Revit-2026-MCP-Server C# command set (MCPCommandHandler.cs)
+to native pyRevit routes. Lengths in FEET.
+
+Routes: detect_document_type, add_project_shared_parameter,
+        remove_project_shared_parameter, get_project_shared_parameters,
+        add_family_shared_parameter, remove_family_parameter, get_family_parameters,
+        create_reference_plane, get_reference_planes, set_graphic_overrides
+"""
+
+from utils import get_element_name, element_id_value
+from pyrevit import routes, DB
+import json
+import traceback
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _parse(request):
+    if not request or not request.data:
+        return {}
+    return json.loads(request.data) if isinstance(request.data, str) else request.data
+
+
+def _group_type_id(name):
+    """Map a parameter-group name to a DB.GroupTypeId (Revit 2024+)."""
+    G = DB.GroupTypeId
+    m = {
+        "general": G.General, "geometry": G.Geometry, "identity": G.IdentityData,
+        "identitydata": G.IdentityData, "construction": G.Construction,
+        "materials": G.Materials, "structural": G.Structural, "text": G.Text,
+        "graphics": G.Graphics, "constraints": G.Constraints, "data": G.Data,
+    }
+    key = (name or "general").lower().replace("pg_", "").replace("_", "").replace(" ", "")
+    return m.get(key, G.General)
+
+
+def _find_category(doc, name):
+    if not name:
+        return None
+    for c in doc.Settings.Categories:
+        if c.Name.lower() == name.lower():
+            return c
+    ost = name if name.startswith("OST_") else "OST_" + name.replace(" ", "")
+    bic = getattr(DB.BuiltInCategory, ost, None)
+    if bic is not None:
+        try:
+            return DB.Category.GetCategory(doc, bic)
+        except Exception:
+            return None
+    return None
+
+
+def _open_shared_def(doc, path, param_name):
+    """Open shared param file, return (ExternalDefinition, group_name) or (None, err)."""
+    try:
+        doc.Application.SharedParametersFilename = path
+        df = doc.Application.OpenSharedParameterFile()
+    except Exception as e:
+        return None, "Failed to open shared parameter file: %s" % e
+    if df is None:
+        return None, "Could not open shared parameter file at '%s'" % path
+    for grp in df.Groups:
+        for d in grp.Definitions:
+            if d.Name.lower() == param_name.lower():
+                return d, grp.Name
+    return None, "Parameter '%s' not found in shared parameter file" % param_name
+
+
+def _parse_color(v):
+    if isinstance(v, (list, tuple)) and len(v) >= 3:
+        return DB.Color(int(v[0]), int(v[1]), int(v[2]))
+    if isinstance(v, str):
+        parts = [int(x) for x in v.replace(" ", "").split(",")]
+        if len(parts) >= 3:
+            return DB.Color(parts[0], parts[1], parts[2])
+    return None
+
+
+def register_shared_param_routes(api):
+
+    @api.route("/detect_document_type/", methods=["GET"])
+    def detect_document_type(doc):
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active document"}, status=503)
+            fam = doc.IsFamilyDocument
+            return routes.make_response(data={
+                "status": "success", "is_family_document": fam, "is_project_document": not fam,
+                "document_type": "Family (.rfa)" if fam else "Project (.rvt)",
+                "document_title": doc.Title,
+                "can_add_project_shared_parameters": not fam,
+                "can_edit_family_parameters": fam,
+            })
+        except Exception as e:
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    @api.route("/add_project_shared_parameter/", methods=["POST"])
+    def add_project_shared_parameter(doc, request):
+        """Bind a shared parameter (from the shared-param file) to categories in a project.
+        Body: {"shared_parameter_file": "...txt", "parameter_name": "Generic Size",
+               "categories": ["Structural Framing","Structural Columns"],
+               "parameter_group": "Structural", "is_instance": true}"""
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active document"}, status=503)
+            if doc.IsFamilyDocument:
+                return routes.make_response(data={"error": "Project command; use add_family_shared_parameter in families."}, status=400)
+            b = _parse(request)
+            for req in ("shared_parameter_file", "parameter_name", "categories"):
+                if not b.get(req):
+                    return routes.make_response(data={"error": "%s is required" % req}, status=400)
+            ext_def, info = _open_shared_def(doc, b["shared_parameter_file"], b["parameter_name"])
+            if ext_def is None:
+                return routes.make_response(data={"error": info}, status=404)
+            gid = _group_type_id(b.get("parameter_group", "General"))
+            is_inst = bool(b.get("is_instance", True))
+            catset = doc.Application.Create.NewCategorySet()
+            added, failed = [], []
+            for cn in b["categories"]:
+                cat = _find_category(doc, cn)
+                if cat is not None and cat.AllowsBoundParameters:
+                    catset.Insert(cat); added.append(cat.Name)
+                else:
+                    failed.append(cn)
+            if catset.Size == 0:
+                return routes.make_response(data={"error": "No valid bindable categories", "failed": failed}, status=400)
+            binding = (doc.Application.Create.NewInstanceBinding(catset) if is_inst
+                       else doc.Application.Create.NewTypeBinding(catset))
+            t = DB.Transaction(doc, "Add Project Shared Parameter"); t.Start()
+            try:
+                bm = doc.ParameterBindings
+                existing = None
+                it = bm.ForwardIterator()
+                while it.MoveNext():
+                    if it.Key.Name.lower() == b["parameter_name"].lower():
+                        existing = it.Key; break
+                ok = bm.ReInsert(existing, binding, gid) if existing else bm.Insert(ext_def, binding, gid)
+                if not ok:
+                    t.RollBack()
+                    return routes.make_response(data={"error": "Failed to bind parameter"}, status=500)
+                t.Commit()
+            except Exception as tx:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                raise tx
+            return routes.make_response(data={"status": "success", "parameter_name": b["parameter_name"],
+                                              "is_instance": is_inst, "shared_param_group": info,
+                                              "bound_categories": added, "failed_categories": failed,
+                                              "was_update": existing is not None})
+        except Exception as e:
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    @api.route("/remove_project_shared_parameter/", methods=["POST"])
+    def remove_project_shared_parameter(doc, request):
+        """Body: {"parameter_name": "Generic Size"}"""
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active document"}, status=503)
+            if doc.IsFamilyDocument:
+                return routes.make_response(data={"error": "Project command."}, status=400)
+            name = _parse(request).get("parameter_name")
+            if not name:
+                return routes.make_response(data={"error": "parameter_name is required"}, status=400)
+            bm = doc.ParameterBindings
+            target, binding = None, None
+            it = bm.ForwardIterator()
+            while it.MoveNext():
+                if it.Key.Name.lower() == name.lower():
+                    target = it.Key; binding = it.Current; break
+            if target is None:
+                return routes.make_response(data={"error": "Parameter '%s' not bound" % name}, status=404)
+            cats = [c.Name for c in binding.Categories] if binding else []
+            t = DB.Transaction(doc, "Remove Project Shared Parameter"); t.Start()
+            try:
+                ok = bm.Remove(target)
+                if not ok:
+                    t.RollBack(); return routes.make_response(data={"error": "Failed to remove"}, status=500)
+                t.Commit()
+            except Exception as tx:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                raise tx
+            return routes.make_response(data={"status": "success", "removed_parameter": name, "was_bound_to": cats})
+        except Exception as e:
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    @api.route("/get_project_shared_parameters/", methods=["GET"])
+    def get_project_shared_parameters(doc):
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active document"}, status=503)
+            if doc.IsFamilyDocument:
+                return routes.make_response(data={"error": "Project command."}, status=400)
+            out = []
+            it = doc.ParameterBindings.ForwardIterator()
+            while it.MoveNext():
+                d = it.Key; binding = it.Current
+                cats = [c.Name for c in binding.Categories] if binding else []
+                rec = {"name": d.Name, "is_instance": isinstance(binding, DB.InstanceBinding),
+                       "bound_categories": cats, "category_count": len(cats),
+                       "is_shared": isinstance(d, DB.ExternalDefinition)}
+                if isinstance(d, DB.ExternalDefinition):
+                    try:
+                        rec["guid"] = str(d.GUID)
+                    except Exception:
+                        pass
+                out.append(rec)
+            return routes.make_response(data={"status": "success", "parameter_count": len(out), "parameters": out})
+        except Exception as e:
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    @api.route("/add_family_shared_parameter/", methods=["POST"])
+    def add_family_shared_parameter(doc, request):
+        """In a family doc: add a shared parameter. Body like add_project_shared_parameter (no categories)."""
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active document"}, status=503)
+            if not doc.IsFamilyDocument:
+                return routes.make_response(data={"error": "Family Editor only."}, status=400)
+            b = _parse(request)
+            for req in ("shared_parameter_file", "parameter_name"):
+                if not b.get(req):
+                    return routes.make_response(data={"error": "%s is required" % req}, status=400)
+            fm = doc.FamilyManager
+            ext_def, info = _open_shared_def(doc, b["shared_parameter_file"], b["parameter_name"])
+            if ext_def is None:
+                return routes.make_response(data={"error": info}, status=404)
+            for fp in fm.Parameters:
+                if fp.Definition.Name.lower() == b["parameter_name"].lower():
+                    return routes.make_response(data={"error": "Parameter already exists in family"}, status=400)
+            gid = _group_type_id(b.get("parameter_group", "General"))
+            is_inst = bool(b.get("is_instance", True))
+            t = DB.Transaction(doc, "Add Family Shared Parameter"); t.Start()
+            try:
+                np = fm.AddParameter(ext_def, gid, is_inst)
+                t.Commit()
+            except Exception as tx:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                raise tx
+            return routes.make_response(data={"status": "success", "parameter_name": np.Definition.Name,
+                                              "is_instance": np.IsInstance, "is_shared": np.IsShared,
+                                              "shared_param_group": info})
+        except Exception as e:
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    @api.route("/remove_family_parameter/", methods=["POST"])
+    def remove_family_parameter(doc, request):
+        """In a family doc: Body {"parameter_name": "..."}"""
+        try:
+            if not doc or not doc.IsFamilyDocument:
+                return routes.make_response(data={"error": "Family Editor only."}, status=400)
+            name = _parse(request).get("parameter_name")
+            if not name:
+                return routes.make_response(data={"error": "parameter_name is required"}, status=400)
+            fm = doc.FamilyManager
+            target = None
+            for fp in fm.Parameters:
+                if fp.Definition.Name.lower() == name.lower():
+                    target = fp; break
+            if target is None:
+                return routes.make_response(data={"error": "Parameter not found"}, status=404)
+            t = DB.Transaction(doc, "Remove Family Parameter"); t.Start()
+            try:
+                fm.RemoveParameter(target); t.Commit()
+            except Exception as tx:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                raise tx
+            return routes.make_response(data={"status": "success", "removed_parameter": name})
+        except Exception as e:
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    @api.route("/get_family_parameters/", methods=["GET"])
+    def get_family_parameters(doc):
+        try:
+            if not doc or not doc.IsFamilyDocument:
+                return routes.make_response(data={"error": "Family Editor only."}, status=400)
+            fm = doc.FamilyManager
+            out = []
+            for fp in fm.Parameters:
+                out.append({"name": fp.Definition.Name, "is_instance": fp.IsInstance,
+                            "is_shared": fp.IsShared, "storage_type": str(fp.StorageType),
+                            "is_read_only": fp.IsReadOnly})
+            return routes.make_response(data={"status": "success", "parameter_count": len(out), "parameters": out})
+        except Exception as e:
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    @api.route("/create_reference_plane/", methods=["POST"])
+    def create_reference_plane(doc, request):
+        """Body: {"bubble":{"x","y","z"}, "free":{"x","y","z"}, "cut_vector":{...}(opt),
+                  "name":"...", "view_name":"...", "view_id":int}  (feet)"""
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active document"}, status=503)
+            b = _parse(request)
+            if not b.get("bubble") or not b.get("free"):
+                return routes.make_response(data={"error": "bubble and free points required"}, status=400)
+            P = lambda d: DB.XYZ(float(d.get("x", 0)), float(d.get("y", 0)), float(d.get("z", 0)))
+            bubble, free = P(b["bubble"]), P(b["free"])
+            if b.get("cut_vector"):
+                cut = P(b["cut_vector"]).Normalize()
+            else:
+                direction = (free - bubble).Normalize()
+                cut = direction.CrossProduct(DB.XYZ.BasisZ)
+                cut = DB.XYZ.BasisY if cut.IsZeroLength() else cut.Normalize()
+            view = None
+            if b.get("view_id"):
+                el = doc.GetElement(DB.ElementId(int(b["view_id"])))
+                view = el if isinstance(el, DB.View) else None
+            elif b.get("view_name"):
+                for v in DB.FilteredElementCollector(doc).OfClass(DB.View):
+                    if not v.IsTemplate and get_element_name(v) == b["view_name"]:
+                        view = v; break
+            if view is None:
+                view = doc.ActiveView
+            t = DB.Transaction(doc, "Create Reference Plane"); t.Start()
+            try:
+                rp = doc.Create.NewReferencePlane(bubble, free, cut, view)
+                if b.get("name"):
+                    try: rp.Name = b["name"]
+                    except Exception: pass
+                t.Commit()
+            except Exception as tx:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                raise tx
+            return routes.make_response(data={"status": "success", "reference_plane_id": element_id_value(rp.Id),
+                                              "name": rp.Name, "view": get_element_name(view)})
+        except Exception as e:
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    @api.route("/get_reference_planes/", methods=["POST"])
+    def get_reference_planes(doc, request):
+        """Body: {"name":"filter"(opt), "include_unnamed":true}"""
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active document"}, status=503)
+            b = _parse(request)
+            nf = (b.get("name") or "").lower()
+            inc_unnamed = bool(b.get("include_unnamed", True))
+            out = []
+            for rp in DB.FilteredElementCollector(doc).OfClass(DB.ReferencePlane):
+                nm = rp.Name or ""
+                if nf and nf not in nm.lower():
+                    continue
+                if not inc_unnamed and not nm.strip():
+                    continue
+                rec = {"id": element_id_value(rp.Id), "name": nm, "is_named": bool(nm.strip())}
+                try:
+                    be, fe = rp.BubbleEnd, rp.FreeEnd
+                    rec["bubble_end"] = {"x": round(be.X, 3), "y": round(be.Y, 3), "z": round(be.Z, 3)}
+                    rec["free_end"] = {"x": round(fe.X, 3), "y": round(fe.Y, 3), "z": round(fe.Z, 3)}
+                except Exception:
+                    pass
+                out.append(rec)
+            return routes.make_response(data={"status": "success", "count": len(out), "reference_planes": out})
+        except Exception as e:
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    @api.route("/set_graphic_overrides/", methods=["POST"])
+    def set_graphic_overrides(doc, request):
+        """Apply view graphic overrides by category or element(s).
+        Body: {"category":"Structural Framing" | "element_ids":[..],
+               "view_name":"..."(opt), "halftone":bool, "transparency":0-100,
+               "projection_line_color":[r,g,b], "projection_line_weight":int,
+               "cut_line_color":[r,g,b], "surface_foreground_color":[r,g,b],
+               "detail_level":"coarse|medium|fine", "reset":bool}"""
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active document"}, status=503)
+            b = _parse(request)
+            view = None
+            if b.get("view_id"):
+                el = doc.GetElement(DB.ElementId(int(b["view_id"])))
+                view = el if isinstance(el, DB.View) else None
+            elif b.get("view_name"):
+                for v in DB.FilteredElementCollector(doc).OfClass(DB.View):
+                    if not v.IsTemplate and get_element_name(v) == b["view_name"]:
+                        view = v; break
+            if view is None:
+                view = doc.ActiveView
+            ogs = DB.OverrideGraphicSettings()
+            if not b.get("reset"):
+                if b.get("halftone") is not None: ogs.SetHalftone(bool(b["halftone"]))
+                if b.get("transparency") is not None:
+                    ogs.SetSurfaceTransparency(max(0, min(100, int(b["transparency"]))))
+                if b.get("projection_line_color"):
+                    c = _parse_color(b["projection_line_color"]);  c and ogs.SetProjectionLineColor(c)
+                if b.get("projection_line_weight") is not None:
+                    ogs.SetProjectionLineWeight(int(b["projection_line_weight"]))
+                if b.get("cut_line_color"):
+                    c = _parse_color(b["cut_line_color"]); c and ogs.SetCutLineColor(c)
+                if b.get("surface_foreground_color"):
+                    c = _parse_color(b["surface_foreground_color"]); c and ogs.SetSurfaceForegroundPatternColor(c)
+                if b.get("detail_level"):
+                    dl = {"coarse": DB.ViewDetailLevel.Coarse, "medium": DB.ViewDetailLevel.Medium,
+                          "fine": DB.ViewDetailLevel.Fine}.get(str(b["detail_level"]).lower())
+                    if dl is not None: ogs.SetDetailLevel(dl)
+            t = DB.Transaction(doc, "Set Graphic Overrides"); t.Start()
+            n = 0
+            try:
+                if b.get("category"):
+                    cat = _find_category(doc, b["category"])
+                    if cat is None:
+                        t.RollBack(); return routes.make_response(data={"error": "category not found"}, status=404)
+                    view.SetCategoryOverrides(cat.Id, ogs); n = 1
+                else:
+                    ids = b.get("element_ids") or ([b["element_id"]] if b.get("element_id") else [])
+                    for i in ids:
+                        view.SetElementOverrides(DB.ElementId(int(i)), ogs); n += 1
+                t.Commit()
+            except Exception as tx:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                raise tx
+            return routes.make_response(data={"status": "success", "view": get_element_name(view),
+                                              "applied_to": n, "reset": bool(b.get("reset"))})
+        except Exception as e:
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    logger.info("Shared-parameter routes registered successfully")

--- a/revit_mcp/structure.py
+++ b/revit_mcp/structure.py
@@ -1,0 +1,280 @@
+# -*- coding: UTF-8 -*-
+"""
+Structure Module for Revit MCP
+Handles grid creation and structural framing placement
+"""
+
+from utils import get_element_name, find_family_symbol_safely, get_element_id_value
+from pyrevit import routes, revit, DB
+import json
+import traceback
+import logging
+
+logger = logging.getLogger(__name__)
+
+MM_TO_FEET = 1.0 / 304.8
+
+
+def register_structure_routes(api):
+    """Register all structure routes with the API"""
+
+    @api.route("/create_grid/", methods=["POST"])
+    def create_grid_handler(doc, request):
+        """Create grid lines in the Revit model."""
+        try:
+            if not doc:
+                return routes.make_response(
+                    data={"error": "No active Revit document"}, status=503
+                )
+
+            if not request or not request.data:
+                return routes.make_response(
+                    data={"error": "No data provided"}, status=400
+                )
+
+            data = json.loads(request.data) if isinstance(request.data, str) else request.data
+
+            grids = data.get("grids", [])
+            if not grids:
+                return routes.make_response(
+                    data={"error": "No grids provided"}, status=400
+                )
+
+            t = DB.Transaction(doc, "Create Grids via MCP")
+            t.Start()
+
+            try:
+                created = []
+
+                for i, grid_def in enumerate(grids):
+                    sp = grid_def.get("start_point", {})
+                    ep = grid_def.get("end_point", {})
+                    name = grid_def.get("name")
+
+                    # Convert mm to feet
+                    start = DB.XYZ(
+                        float(sp.get("x", 0)) * MM_TO_FEET,
+                        float(sp.get("y", 0)) * MM_TO_FEET,
+                        float(sp.get("z", 0)) * MM_TO_FEET,
+                    )
+                    end = DB.XYZ(
+                        float(ep.get("x", 0)) * MM_TO_FEET,
+                        float(ep.get("y", 0)) * MM_TO_FEET,
+                        float(ep.get("z", 0)) * MM_TO_FEET,
+                    )
+
+                    # Validate non-zero length
+                    length = start.DistanceTo(end)
+                    if length < 0.001:
+                        logger.warning("Grid {} has zero length, skipping".format(i))
+                        continue
+
+                    line = DB.Line.CreateBound(start, end)
+                    grid = DB.Grid.Create(doc, line)
+
+                    if name:
+                        try:
+                            grid.Name = name
+                        except Exception as name_err:
+                            logger.warning("Could not set grid name '{}': {}".format(
+                                name, str(name_err)
+                            ))
+
+                    grid_name = get_element_name(grid)
+                    created.append({
+                        "id": get_element_id_value(grid),
+                        "name": grid_name,
+                    })
+
+                t.Commit()
+
+                message = "Created {} grid line{}".format(
+                    len(created),
+                    "s" if len(created) != 1 else ""
+                )
+
+                return routes.make_response(
+                    data={
+                        "status": "success",
+                        "created": created,
+                        "count": len(created),
+                        "message": message,
+                    }
+                )
+
+            except Exception as tx_error:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                raise tx_error
+
+        except Exception as e:
+            logger.error("Failed to create grids: {}".format(str(e)))
+            error_trace = traceback.format_exc()
+            return routes.make_response(
+                data={"error": str(e), "traceback": error_trace}, status=500
+            )
+
+    @api.route("/create_framing/", methods=["POST"])
+    def create_framing_handler(doc, request):
+        """Create structural framing (beams) in the Revit model."""
+        try:
+            if not doc:
+                return routes.make_response(
+                    data={"error": "No active Revit document"}, status=503
+                )
+
+            if not request or not request.data:
+                return routes.make_response(
+                    data={"error": "No data provided"}, status=400
+                )
+
+            data = json.loads(request.data) if isinstance(request.data, str) else request.data
+
+            elements = data.get("elements", [])
+            if not elements:
+                return routes.make_response(
+                    data={"error": "No elements provided"}, status=400
+                )
+
+            # Find structural framing types
+            framing_symbols = (
+                DB.FilteredElementCollector(doc)
+                .OfCategory(DB.BuiltInCategory.OST_StructuralFraming)
+                .OfClass(DB.FamilySymbol)
+                .ToElements()
+            )
+
+            if not framing_symbols or len(framing_symbols) == 0:
+                return routes.make_response(
+                    data={"error": "No structural framing types found — load beam families into the project"},
+                    status=404,
+                )
+
+            # Get available levels
+            levels = (
+                DB.FilteredElementCollector(doc)
+                .OfCategory(DB.BuiltInCategory.OST_Levels)
+                .WhereElementIsNotElementType()
+                .ToElements()
+            )
+
+            t = DB.Transaction(doc, "Create Structural Framing via MCP")
+            t.Start()
+
+            try:
+                created = []
+
+                for elem_def in elements:
+                    sp = elem_def.get("start_point", {})
+                    ep = elem_def.get("end_point", {})
+                    type_name = elem_def.get("type_name")
+                    level_name = elem_def.get("level_name")
+                    name = elem_def.get("name", "")
+
+                    # Convert mm to feet
+                    start = DB.XYZ(
+                        float(sp.get("x", 0)) * MM_TO_FEET,
+                        float(sp.get("y", 0)) * MM_TO_FEET,
+                        float(sp.get("z", 0)) * MM_TO_FEET,
+                    )
+                    end = DB.XYZ(
+                        float(ep.get("x", 0)) * MM_TO_FEET,
+                        float(ep.get("y", 0)) * MM_TO_FEET,
+                        float(ep.get("z", 0)) * MM_TO_FEET,
+                    )
+
+                    # Validate non-zero length
+                    length = start.DistanceTo(end)
+                    if length < 0.001:
+                        logger.warning("Beam has zero length, skipping")
+                        continue
+
+                    # Find the beam type
+                    target_symbol = None
+                    if type_name:
+                        for sym in framing_symbols:
+                            try:
+                                sym_name = get_element_name(sym)
+                                if sym_name == type_name:
+                                    target_symbol = sym
+                                    break
+                            except Exception:
+                                continue
+
+                    if not target_symbol:
+                        target_symbol = framing_symbols[0]
+
+                    # Find level
+                    target_level = None
+                    if level_name:
+                        for level in levels:
+                            try:
+                                if get_element_name(level) == level_name:
+                                    target_level = level
+                                    break
+                            except Exception:
+                                continue
+
+                    if not target_level and levels:
+                        target_level = levels[0]
+
+                    # Activate symbol
+                    if not target_symbol.IsActive:
+                        target_symbol.Activate()
+                        doc.Regenerate()
+
+                    # Create curve for beam
+                    curve = DB.Line.CreateBound(start, end)
+
+                    # Create the beam
+                    beam = doc.Create.NewFamilyInstance(
+                        curve,
+                        target_symbol,
+                        target_level,
+                        DB.Structure.StructuralType.Beam,
+                    )
+
+                    beam_type = get_element_name(target_symbol)
+                    beam_level = get_element_name(target_level) if target_level else "Unknown"
+
+                    created.append({
+                        "id": get_element_id_value(beam),
+                        "name": name,
+                        "type": beam_type,
+                        "level": beam_level,
+                    })
+
+                t.Commit()
+
+                level_msg = ""
+                if created and created[0].get("level"):
+                    level_msg = " on {}".format(created[0]["level"])
+
+                message = "Created {} structural framing element{}{}".format(
+                    len(created),
+                    "s" if len(created) != 1 else "",
+                    level_msg,
+                )
+
+                return routes.make_response(
+                    data={
+                        "status": "success",
+                        "created": created,
+                        "count": len(created),
+                        "message": message,
+                    }
+                )
+
+            except Exception as tx_error:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                raise tx_error
+
+        except Exception as e:
+            logger.error("Failed to create framing: {}".format(str(e)))
+            error_trace = traceback.format_exc()
+            return routes.make_response(
+                data={"error": str(e), "traceback": error_trace}, status=500
+            )
+
+    logger.info("Structure routes registered successfully")

--- a/revit_mcp/structure_framing.py
+++ b/revit_mcp/structure_framing.py
@@ -403,4 +403,166 @@ def register_structure_framing_routes(api):
         except Exception as e:
             return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
 
+    # ------------------------------------------------ KPFF shared-param setter
+    @api.route("/set_parameters_bulk/", methods=["POST"])
+    def set_parameters_bulk(doc, request):
+        """
+        Set parameters (incl. KPFF shared parameters) on many elements at once.
+        Body: {"elements": [{"id": 12345, "params": {"Generic Size": "W16x26",
+                                                       "Number of Studs": 20}}, ...]}
+        Coerces by storage type (String/Integer/Double/ElementId). Useful for
+        populating WF Wt / Framing / Joist Elevation Parameters etc. that drive KPFF tags.
+        """
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active document"}, status=503)
+            data = _parse(request) or {}
+            elements = data.get("elements") or []
+            if not elements:
+                return routes.make_response(data={"error": "No 'elements' provided"}, status=400)
+            t = DB.Transaction(doc, "MCP Set Parameters")
+            t.Start()
+            results = []
+            try:
+                for spec in elements:
+                    e = doc.GetElement(DB.ElementId(int(spec["id"])))
+                    if not e:
+                        results.append({"id": spec.get("id"), "error": "not found"})
+                        continue
+                    set_ok = []
+                    failed = []
+                    for name, value in (spec.get("params") or {}).items():
+                        p = e.LookupParameter(name)
+                        if not p or p.IsReadOnly:
+                            failed.append(name)
+                            continue
+                        st = p.StorageType
+                        try:
+                            if st == DB.StorageType.String:
+                                p.Set(str(value))
+                            elif st == DB.StorageType.Integer:
+                                p.Set(int(value))
+                            elif st == DB.StorageType.Double:
+                                p.Set(float(value))
+                            elif st == DB.StorageType.ElementId:
+                                p.Set(DB.ElementId(int(value)))
+                            else:
+                                failed.append(name)
+                                continue
+                            set_ok.append(name)
+                        except Exception:
+                            failed.append(name)
+                    results.append({"id": element_id_value(e.Id), "set": set_ok, "failed": failed})
+                t.Commit()
+            except Exception as tx:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                raise tx
+            return routes.make_response(data={"status": "success", "results": results})
+        except Exception as e:
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    # ---------------------------------------- KPFF standard framing plan tagger
+    @api.route("/tag_framing_standard/", methods=["POST"])
+    def tag_framing_standard(doc, request):
+        """
+        Tag all framing in a view with the KPFF standard framing tag, oriented
+        parallel to each member (vertical text for N-S members, horizontal for E-W).
+        Body: {"view_name": "2 - Level 2",
+               "tag_family": "KPFF_Tag_Framing", "tag_type": "Standard - T/Elevation",
+               "level": "2nd Level"}
+        Default tag is the composite T/STL standard (Size [studs] C{camber} (drop) T/STL elev).
+        """
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active document"}, status=503)
+            data = _parse(request) or {}
+            view = _view_by_name(doc, data.get("view_name"))
+            if not view:
+                return routes.make_response(data={"error": "view not found"}, status=404)
+            tag = find_family_symbol_safely(doc, data.get("tag_family", "KPFF_Tag_Framing"),
+                                            data.get("tag_type", "Standard - T/Elevation"))
+            if not tag:
+                return routes.make_response(data={"error": "framing tag type not found"}, status=404)
+            only_level = data.get("level")
+            framing = list(DB.FilteredElementCollector(doc)
+                           .OfCategory(DB.BuiltInCategory.OST_StructuralFraming)
+                           .WhereElementIsNotElementType())
+            t = DB.Transaction(doc, "MCP Tag Framing (KPFF standard)")
+            t.Start()
+            n = 0
+            try:
+                if not tag.IsActive:
+                    tag.Activate()
+                    doc.Regenerate()
+                for e in framing:
+                    if only_level:
+                        p = e.get_Parameter(DB.BuiltInParameter.INSTANCE_REFERENCE_LEVEL_PARAM)
+                        if not p or p.AsElementId().IntegerValue <= 0:
+                            continue
+                        if get_element_name(doc.GetElement(p.AsElementId())) != only_level:
+                            continue
+                    try:
+                        crv = e.Location.Curve
+                        a = crv.GetEndPoint(0)
+                        b = crv.GetEndPoint(1)
+                        m = crv.Evaluate(0.5, True)
+                        is_ns = abs(b.Y - a.Y) > abs(b.X - a.X)
+                        orient = DB.TagOrientation.Vertical if is_ns else DB.TagOrientation.Horizontal
+                        DB.IndependentTag.Create(doc, tag.Id, view.Id, DB.Reference(e),
+                                                 False, orient, DB.XYZ(m.X, m.Y, 0))
+                        n += 1
+                    except Exception:
+                        continue
+                t.Commit()
+            except Exception as tx:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                raise tx
+            return routes.make_response(data={"status": "success", "tagged": n})
+        except Exception as e:
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    # ---------------------------------------------- KPFF composite slab callout
+    @api.route("/create_slab_callout/", methods=["POST"])
+    def create_slab_callout(doc, request):
+        """
+        Place the KPFF composite-floor slab callout as a text note in a view.
+        Body: {"view_name": "2 - Level 2", "x": 60, "y": 50,
+               "t_slab": "17'-0\"", "nw_thickness": "3\"", "deck": "2VLI20",
+               "total_thickness": "5\"", "reinf": "#4@12\" OC", "text": "<override full text>"}
+        Default text matches: T/SLAB {t} / {nw} NORMAL-WEIGHT OVER {deck} GALV COMPOSITE
+        FLOOR DECK ({total} TOTAL THICKNESS) REINF w/ {reinf} (TYP-UNO).
+        """
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active document"}, status=503)
+            d = _parse(request) or {}
+            view = _view_by_name(doc, d.get("view_name"))
+            if not view:
+                return routes.make_response(data={"error": "view not found"}, status=404)
+            text = d.get("text")
+            if not text:
+                text = ('T/SLAB %s\n%s NORMAL-WEIGHT OVER %s GALV COMPOSITE FLOOR DECK '
+                        '(%s TOTAL THICKNESS)\nREINF w/ %s (TYP-UNO)' % (
+                            d.get("t_slab", "0'-0\""), d.get("nw_thickness", "3\""),
+                            d.get("deck", "2VLI20"), d.get("total_thickness", "5\""),
+                            d.get("reinf", "#4@12\" OC")))
+            tnt = DB.FilteredElementCollector(doc).OfClass(DB.TextNoteType).FirstElement()
+            t = DB.Transaction(doc, "MCP Slab Callout")
+            t.Start()
+            try:
+                note = DB.TextNote.Create(doc, view.Id,
+                                          DB.XYZ(float(d.get("x", 0)), float(d.get("y", 0)), 0),
+                                          text, tnt.Id)
+                t.Commit()
+            except Exception as tx:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                raise tx
+            return routes.make_response(data={"status": "success",
+                                              "text_note_id": element_id_value(note.Id), "text": text})
+        except Exception as e:
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
     logger.info("Structural framing routes registered successfully")

--- a/revit_mcp/structure_framing.py
+++ b/revit_mcp/structure_framing.py
@@ -1,0 +1,406 @@
+# -*- coding: UTF-8 -*-
+"""
+Structural Framing Module for Revit MCP
+Net-new capabilities developed for RAM-plot -> Revit modeling:
+  - create_grids            : batch grid creation from line coordinates
+  - configure_levels        : set elevation and/or rename levels
+  - place_framing           : batch line-based framing (beams / joists)
+  - create_beam_system      : structural beam system over a rectangular bay
+  - tag_all_framing         : tag every framing member (and optionally columns) in a view
+  - create_sheet            : new sheet with a title block and a placed view
+
+All lengths are in feet (Revit internal units).
+"""
+
+from utils import get_element_name, find_family_symbol_safely, element_id_value
+from pyrevit import routes, DB
+import json
+import traceback
+import logging
+
+logger = logging.getLogger(__name__)
+ST = DB.Structure.StructuralType
+
+
+def _parse(request):
+    """Return parsed dict body or None."""
+    if not request or not request.data:
+        return None
+    if isinstance(request.data, str):
+        return json.loads(request.data)
+    return request.data
+
+
+def _find_symbol_by_category(doc, family_name, type_name):
+    """Resolve a FamilySymbol by family + type name."""
+    return find_family_symbol_safely(doc, family_name, type_name)
+
+
+def _level_by_name(doc, name):
+    for lvl in (DB.FilteredElementCollector(doc)
+                .OfCategory(DB.BuiltInCategory.OST_Levels)
+                .WhereElementIsNotElementType().ToElements()):
+        if get_element_name(lvl) == name:
+            return lvl
+    return None
+
+
+def _view_by_name(doc, name):
+    for v in DB.FilteredElementCollector(doc).OfClass(DB.View).ToElements():
+        if not v.IsTemplate and get_element_name(v) == name:
+            return v
+    return None
+
+
+def register_structure_framing_routes(api):
+    """Register structural framing routes with the API."""
+
+    # ------------------------------------------------------------------ grids
+    @api.route("/create_grids/", methods=["POST"])
+    def create_grids(doc, request):
+        """
+        Create multiple grids.
+        Body: {"grids": [{"name": "A", "x0": 0, "y0": -5, "x1": 0, "y1": 120}, ...]}
+        Each grid is a straight line between (x0,y0) and (x1,y1) at z=0.
+        """
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active document"}, status=503)
+            data = _parse(request)
+            grids = (data or {}).get("grids")
+            if not grids:
+                return routes.make_response(data={"error": "No 'grids' provided"}, status=400)
+            t = DB.Transaction(doc, "MCP Create Grids")
+            t.Start()
+            made = []
+            try:
+                for g in grids:
+                    ln = DB.Line.CreateBound(
+                        DB.XYZ(float(g["x0"]), float(g["y0"]), 0.0),
+                        DB.XYZ(float(g["x1"]), float(g["y1"]), 0.0))
+                    grid = DB.Grid.Create(doc, ln)
+                    if g.get("name"):
+                        try:
+                            grid.Name = g["name"]
+                        except Exception as ne:
+                            logger.warning("grid name '%s': %s", g.get("name"), ne)
+                    made.append({"id": element_id_value(grid.Id), "name": get_element_name(grid)})
+                t.Commit()
+            except Exception as tx:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                raise tx
+            return routes.make_response(data={"status": "success", "created": made, "count": len(made)})
+        except Exception as e:
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    # ----------------------------------------------------------------- levels
+    @api.route("/configure_levels/", methods=["POST"])
+    def configure_levels(doc, request):
+        """
+        Set elevation and/or rename existing levels.
+        Body: {"levels": [{"name": "Level 2", "elevation": 16.583, "new_name": "2nd Level"}, ...]}
+        """
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active document"}, status=503)
+            data = _parse(request)
+            specs = (data or {}).get("levels")
+            if not specs:
+                return routes.make_response(data={"error": "No 'levels' provided"}, status=400)
+            t = DB.Transaction(doc, "MCP Configure Levels")
+            t.Start()
+            res = []
+            try:
+                for s in specs:
+                    lvl = _level_by_name(doc, s.get("name")) or _level_by_name(doc, s.get("new_name", ""))
+                    if not lvl:
+                        res.append({"name": s.get("name"), "error": "not found"})
+                        continue
+                    if "elevation" in s and s["elevation"] is not None:
+                        lvl.Elevation = float(s["elevation"])
+                    if s.get("new_name"):
+                        try:
+                            lvl.Name = s["new_name"]
+                        except Exception as ne:
+                            res.append({"name": s.get("name"), "rename_error": str(ne)})
+                    res.append({"name": get_element_name(lvl), "elevation": round(lvl.Elevation, 4)})
+                t.Commit()
+            except Exception as tx:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                raise tx
+            return routes.make_response(data={"status": "success", "levels": res})
+        except Exception as e:
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    # ---------------------------------------------------------------- framing
+    @api.route("/place_framing/", methods=["POST"])
+    def place_framing(doc, request):
+        """
+        Batch-place line-based structural framing (beams / joists).
+        Body: {
+          "level": "2nd Level",
+          "members": [
+             {"family": "5 W Shapes", "type": "W16x26",
+              "x0": 0, "y0": 0, "x1": 20, "y1": 0,
+              "z_justification": "top", "z_offset": 0.0}
+          ]
+        }
+        z_justification: top|center|bottom|origin (default top). Coordinates in feet at the level.
+        """
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active document"}, status=503)
+            data = _parse(request)
+            members = (data or {}).get("members")
+            if not members:
+                return routes.make_response(data={"error": "No 'members' provided"}, status=400)
+            default_level = (data or {}).get("level")
+            zmap = {"top": 0, "center": 1, "bottom": 2, "origin": 3}
+
+            t = DB.Transaction(doc, "MCP Place Framing")
+            t.Start()
+            placed = 0
+            errors = []
+            try:
+                symcache = {}
+                for m in members:
+                    key = (m["family"], m["type"])
+                    sym = symcache.get(key)
+                    if sym is None:
+                        sym = _find_symbol_by_category(doc, m["family"], m["type"])
+                        symcache[key] = sym
+                    if not sym:
+                        errors.append("symbol not found: {} : {}".format(m["family"], m["type"]))
+                        continue
+                    if not sym.IsActive:
+                        sym.Activate()
+                        doc.Regenerate()
+                    lvl = _level_by_name(doc, m.get("level", default_level))
+                    if not lvl:
+                        errors.append("level not found: {}".format(m.get("level", default_level)))
+                        continue
+                    z = lvl.Elevation
+                    p0 = DB.XYZ(float(m["x0"]), float(m["y0"]), z)
+                    p1 = DB.XYZ(float(m["x1"]), float(m["y1"]), z)
+                    if p0.DistanceTo(p1) < 0.1:
+                        errors.append("degenerate member skipped")
+                        continue
+                    inst = doc.Create.NewFamilyInstance(
+                        DB.Line.CreateBound(p0, p1), sym, lvl, ST.Beam)
+                    zj = inst.get_Parameter(DB.BuiltInParameter.Z_JUSTIFICATION)
+                    if zj and m.get("z_justification"):
+                        zj.Set(zmap.get(str(m["z_justification"]).lower(), 0))
+                    zo = inst.get_Parameter(DB.BuiltInParameter.Z_OFFSET_VALUE)
+                    if zo and m.get("z_offset") is not None:
+                        zo.Set(float(m["z_offset"]))
+                    placed += 1
+                t.Commit()
+            except Exception as tx:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                raise tx
+            return routes.make_response(data={"status": "success", "placed": placed,
+                                              "requested": len(members), "errors": errors[:15]})
+        except Exception as e:
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    # ------------------------------------------------------------ beam system
+    @api.route("/create_beam_system/", methods=["POST"])
+    def create_beam_system(doc, request):
+        """
+        Create a structural beam system over a rectangular bay.
+        Body: {
+          "level": "Roof", "family": "5 K Joist", "type": "16K2",
+          "rect": {"xmin": 97.5, "xmax": 158.7, "ymin": 19.8, "ymax": 35.7},
+          "direction": {"x": 0, "y": 1},
+          "layout": {"rule": "fixed_number", "value": 11},   # or "fixed_distance" + spacing
+          "z_justification": "bottom"                        # optional, applied to generated beams
+        }
+        """
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active document"}, status=503)
+            data = _parse(request) or {}
+            lvl = _level_by_name(doc, data.get("level"))
+            if not lvl:
+                return routes.make_response(data={"error": "level not found"}, status=404)
+            sym = _find_symbol_by_category(doc, data.get("family"), data.get("type"))
+            if not sym:
+                return routes.make_response(data={"error": "beam type not found"}, status=404)
+            r = data.get("rect") or {}
+            d = data.get("direction") or {"x": 0, "y": 1}
+            lay = data.get("layout") or {"rule": "fixed_number", "value": 2}
+            z = lvl.Elevation
+            from System.Collections.Generic import List
+            pts = [DB.XYZ(r["xmin"], r["ymin"], z), DB.XYZ(r["xmax"], r["ymin"], z),
+                   DB.XYZ(r["xmax"], r["ymax"], z), DB.XYZ(r["xmin"], r["ymax"], z)]
+            prof = List[DB.Curve]()
+            for i in range(4):
+                prof.Add(DB.Line.CreateBound(pts[i], pts[(i + 1) % 4]))
+            zmap = {"top": 0, "center": 1, "bottom": 2, "origin": 3}
+
+            t = DB.Transaction(doc, "MCP Create Beam System")
+            t.Start()
+            try:
+                if not sym.IsActive:
+                    sym.Activate()
+                    doc.Regenerate()
+                bs = DB.BeamSystem.Create(doc, prof, lvl, DB.XYZ(float(d["x"]), float(d["y"]), 0), False)
+                bs.BeamType = sym
+                if str(lay.get("rule", "fixed_number")) == "fixed_distance":
+                    bs.LayoutRule = DB.LayoutRuleFixedDistance(float(lay["value"]))
+                else:
+                    bs.LayoutRule = DB.LayoutRuleFixedNumber(int(lay["value"]))
+                doc.Regenerate()
+                beam_ids = list(bs.GetBeamIds())
+                if data.get("z_justification"):
+                    jv = zmap.get(str(data["z_justification"]).lower(), 0)
+                    for bid in beam_ids:
+                        be = doc.GetElement(bid)
+                        zj = be.get_Parameter(DB.BuiltInParameter.Z_JUSTIFICATION)
+                        if zj:
+                            zj.Set(jv)
+                t.Commit()
+            except Exception as tx:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                raise tx
+            return routes.make_response(data={"status": "success",
+                                              "beam_system_id": element_id_value(bs.Id),
+                                              "beams": len(beam_ids)})
+        except Exception as e:
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    # ---------------------------------------------------------------- tagging
+    @api.route("/tag_all_framing/", methods=["POST"])
+    def tag_all_framing(doc, request):
+        """
+        Tag every structural framing member in a plan view (optionally columns too).
+        Body: {
+          "view_name": "2 - Level 2",
+          "tag_family": "KPFF_Tag_Framing", "tag_type": "Type",
+          "level": "2nd Level",          # only tag members on this reference level (optional)
+          "include_columns": false,
+          "column_tag_family": "KPFF_Tag_Column", "column_tag_type": "Type Name"
+        }
+        """
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active document"}, status=503)
+            data = _parse(request) or {}
+            view = _view_by_name(doc, data.get("view_name"))
+            if not view:
+                return routes.make_response(data={"error": "view not found"}, status=404)
+            ftag = _find_symbol_by_category(doc, data.get("tag_family"), data.get("tag_type"))
+            if not ftag:
+                return routes.make_response(data={"error": "framing tag type not found"}, status=404)
+            only_level = data.get("level")
+
+            def ref_level_name(e):
+                p = e.get_Parameter(DB.BuiltInParameter.INSTANCE_REFERENCE_LEVEL_PARAM)
+                if p and p.AsElementId().IntegerValue > 0:
+                    return get_element_name(doc.GetElement(p.AsElementId()))
+                return None
+
+            framing = list(DB.FilteredElementCollector(doc)
+                           .OfCategory(DB.BuiltInCategory.OST_StructuralFraming)
+                           .WhereElementIsNotElementType())
+            t = DB.Transaction(doc, "MCP Tag Framing")
+            t.Start()
+            n = 0
+            try:
+                if not ftag.IsActive:
+                    ftag.Activate()
+                    doc.Regenerate()
+                for e in framing:
+                    if only_level and ref_level_name(e) != only_level:
+                        continue
+                    try:
+                        m = e.Location.Curve.Evaluate(0.5, True)
+                        DB.IndependentTag.Create(doc, ftag.Id, view.Id, DB.Reference(e),
+                                                 False, DB.TagOrientation.Horizontal,
+                                                 DB.XYZ(m.X, m.Y, 0))
+                        n += 1
+                    except Exception:
+                        continue
+                nc = 0
+                if data.get("include_columns"):
+                    ctag = _find_symbol_by_category(doc, data.get("column_tag_family"),
+                                                    data.get("column_tag_type"))
+                    if ctag:
+                        if not ctag.IsActive:
+                            ctag.Activate()
+                            doc.Regenerate()
+                        for c in (DB.FilteredElementCollector(doc)
+                                  .OfCategory(DB.BuiltInCategory.OST_StructuralColumns)
+                                  .WhereElementIsNotElementType()):
+                            try:
+                                p = c.Location.Point
+                                DB.IndependentTag.Create(doc, ctag.Id, view.Id, DB.Reference(c),
+                                                         False, DB.TagOrientation.Horizontal,
+                                                         DB.XYZ(p.X + 1.0, p.Y + 1.0, 0))
+                                nc += 1
+                            except Exception:
+                                continue
+                t.Commit()
+            except Exception as tx:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                raise tx
+            return routes.make_response(data={"status": "success", "framing_tagged": n,
+                                              "columns_tagged": nc})
+        except Exception as e:
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    # ----------------------------------------------------------------- sheets
+    @api.route("/create_sheet/", methods=["POST"])
+    def create_sheet(doc, request):
+        """
+        Create a sheet with a title block and place a view on it.
+        Body: {
+          "title_block_family": "KPFF Border_24x36", "title_block_type": "24x36",
+          "sheet_number": "S2.1", "sheet_name": "SECOND FLOOR FRAMING PLAN",
+          "view_name": "2 - Level 2", "x": 1.25, "y": 1.0
+        }
+        """
+        try:
+            if not doc:
+                return routes.make_response(data={"error": "No active document"}, status=503)
+            data = _parse(request) or {}
+            tb = _find_symbol_by_category(doc, data.get("title_block_family"),
+                                          data.get("title_block_type"))
+            if not tb:
+                return routes.make_response(data={"error": "title block not found"}, status=404)
+            t = DB.Transaction(doc, "MCP Create Sheet")
+            t.Start()
+            try:
+                if not tb.IsActive:
+                    tb.Activate()
+                    doc.Regenerate()
+                sheet = DB.ViewSheet.Create(doc, tb.Id)
+                if data.get("sheet_number"):
+                    sheet.SheetNumber = data["sheet_number"]
+                if data.get("sheet_name"):
+                    sheet.Name = data["sheet_name"]
+                placed_view = None
+                view = _view_by_name(doc, data.get("view_name"))
+                if view:
+                    DB.Viewport.Create(doc, sheet.Id, view.Id,
+                                       DB.XYZ(float(data.get("x", 1.25)), float(data.get("y", 1.0)), 0))
+                    placed_view = get_element_name(view)
+                t.Commit()
+            except Exception as tx:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                raise tx
+            return routes.make_response(data={"status": "success",
+                                              "sheet_id": element_id_value(sheet.Id),
+                                              "sheet_number": sheet.SheetNumber,
+                                              "sheet_name": get_element_name(sheet),
+                                              "view_placed": placed_view})
+        except Exception as e:
+            return routes.make_response(data={"error": str(e), "traceback": traceback.format_exc()}, status=500)
+
+    logger.info("Structural framing routes registered successfully")

--- a/revit_mcp/tags.py
+++ b/revit_mcp/tags.py
@@ -1,0 +1,247 @@
+# -*- coding: UTF-8 -*-
+"""
+Tags Module for Revit MCP
+Handles element tagging with annotation symbols
+"""
+
+from utils import get_element_name, get_element_id_value, make_element_id
+from pyrevit import routes, revit, DB
+import json
+import traceback
+import logging
+
+logger = logging.getLogger(__name__)
+
+MM_TO_FEET = 1.0 / 304.8
+
+
+def register_tag_routes(api):
+    """Register all tag routes with the API"""
+
+    @api.route("/tag_elements/", methods=["POST"])
+    def tag_elements_handler(doc, request):
+        """Tag elements with annotation symbols in a view."""
+        try:
+            if not doc:
+                return routes.make_response(
+                    data={"error": "No active Revit document"}, status=503
+                )
+
+            data = json.loads(request.data) if isinstance(request.data, str) else request.data
+
+            element_ids = data.get("element_ids", [])
+            if not element_ids:
+                return routes.make_response(
+                    data={"error": "element_ids is required and must not be empty"},
+                    status=400,
+                )
+
+            # Find the view
+            view_name = data.get("view_name")
+            target_view = None
+            if view_name:
+                views = (
+                    DB.FilteredElementCollector(doc)
+                    .OfClass(DB.View)
+                    .WhereElementIsNotElementType()
+                    .ToElements()
+                )
+                for v in views:
+                    if get_element_name(v) == view_name and not v.IsTemplate:
+                        target_view = v
+                        break
+                if not target_view:
+                    return routes.make_response(
+                        data={"error": "View '{}' not found".format(view_name)},
+                        status=404,
+                    )
+            else:
+                target_view = doc.ActiveView
+
+            add_leader = data.get("add_leader", False)
+            orientation = data.get("orientation", "horizontal")
+            offset = data.get("offset", {})
+            tag_type_name = data.get("tag_type_name")
+
+            offset_x = float(offset.get("x", 0)) * MM_TO_FEET if offset else 0
+            offset_y = float(offset.get("y", 0)) * MM_TO_FEET if offset else 0
+
+            # Determine tag orientation
+            if orientation == "vertical":
+                tag_orientation = DB.TagOrientation.Vertical
+            else:
+                tag_orientation = DB.TagOrientation.Horizontal
+
+            # Map element categories to their tag categories
+            CATEGORY_TO_TAG_CATEGORY = {
+                DB.BuiltInCategory.OST_Walls: DB.BuiltInCategory.OST_WallTags,
+                DB.BuiltInCategory.OST_Doors: DB.BuiltInCategory.OST_DoorTags,
+                DB.BuiltInCategory.OST_Windows: DB.BuiltInCategory.OST_WindowTags,
+                DB.BuiltInCategory.OST_Rooms: DB.BuiltInCategory.OST_RoomTags,
+                DB.BuiltInCategory.OST_Floors: DB.BuiltInCategory.OST_FloorTags,
+                DB.BuiltInCategory.OST_StructuralFraming: DB.BuiltInCategory.OST_StructuralFramingTags,
+                DB.BuiltInCategory.OST_StructuralColumns: DB.BuiltInCategory.OST_StructuralColumnTags,
+            }
+
+            def find_tag_type_for_element(element):
+                """Find the appropriate tag type for an element's category."""
+                elem_cat = element.Category
+                if not elem_cat:
+                    return None
+
+                # Try mapping by BuiltInCategory
+                try:
+                    bic = elem_cat.BuiltInCategory
+                    tag_bic = CATEGORY_TO_TAG_CATEGORY.get(bic)
+                    if tag_bic:
+                        tag_symbols = (
+                            DB.FilteredElementCollector(doc)
+                            .OfCategory(tag_bic)
+                            .OfClass(DB.FamilySymbol)
+                            .ToElements()
+                        )
+                        # If user specified a tag type name, try to match
+                        if tag_type_name:
+                            for ts in tag_symbols:
+                                if get_element_name(ts) == tag_type_name:
+                                    return ts
+                        # Return first available
+                        if tag_symbols and tag_symbols.Count > 0:
+                            return tag_symbols[0]
+                except Exception:
+                    pass
+                return None
+
+            t = DB.Transaction(doc, "Tag Elements via MCP")
+            t.Start()
+
+            try:
+                tagged_ids = []
+                skipped = []
+
+                for eid in element_ids:
+                    elem_id = make_element_id(eid)
+                    elem = doc.GetElement(elem_id)
+
+                    if not elem:
+                        skipped.append({
+                            "element_id": eid,
+                            "reason": "Element not found",
+                        })
+                        continue
+
+                    if not elem.Category:
+                        skipped.append({
+                            "element_id": eid,
+                            "reason": "Element has no category",
+                        })
+                        continue
+
+                    # Find tag type for this element's category
+                    tag_type = find_tag_type_for_element(elem)
+                    if not tag_type:
+                        skipped.append({
+                            "element_id": eid,
+                            "reason": "No tag type found for category '{}'".format(
+                                get_element_name(elem.Category)
+                            ),
+                        })
+                        continue
+
+                    # Ensure tag type is activated
+                    if not tag_type.IsActive:
+                        tag_type.Activate()
+                        doc.Regenerate()
+
+                    # Get element location for tag placement
+                    tag_point = None
+                    try:
+                        loc = elem.Location
+                        if hasattr(loc, "Point"):
+                            pt = loc.Point
+                            tag_point = DB.XYZ(pt.X + offset_x, pt.Y + offset_y, pt.Z)
+                        elif hasattr(loc, "Curve"):
+                            curve = loc.Curve
+                            mid = curve.Evaluate(0.5, True)
+                            tag_point = DB.XYZ(mid.X + offset_x, mid.Y + offset_y, mid.Z)
+                        else:
+                            bb = elem.get_BoundingBox(target_view)
+                            if bb:
+                                center = DB.XYZ(
+                                    (bb.Min.X + bb.Max.X) / 2.0 + offset_x,
+                                    (bb.Min.Y + bb.Max.Y) / 2.0 + offset_y,
+                                    (bb.Min.Z + bb.Max.Z) / 2.0,
+                                )
+                                tag_point = center
+                    except Exception:
+                        bb = elem.get_BoundingBox(target_view)
+                        if bb:
+                            tag_point = DB.XYZ(
+                                (bb.Min.X + bb.Max.X) / 2.0 + offset_x,
+                                (bb.Min.Y + bb.Max.Y) / 2.0 + offset_y,
+                                (bb.Min.Z + bb.Max.Z) / 2.0,
+                            )
+
+                    if not tag_point:
+                        skipped.append({
+                            "element_id": eid,
+                            "reason": "Cannot determine element location",
+                        })
+                        continue
+
+                    try:
+                        # Use IndependentTag.Create (Revit 2024+)
+                        # 7-arg signature: doc, tagTypeId, viewId, ref, addLeader, orientation, point
+                        ref = DB.Reference(elem)
+                        tag = DB.IndependentTag.Create(
+                            doc,
+                            tag_type.Id,
+                            target_view.Id,
+                            ref,
+                            add_leader,
+                            tag_orientation,
+                            tag_point,
+                        )
+
+                        if tag:
+                            tagged_ids.append(get_element_id_value(tag))
+                        else:
+                            skipped.append({
+                                "element_id": eid,
+                                "reason": "Tag creation returned null — no tag type available for this category",
+                            })
+                    except Exception as tag_err:
+                        skipped.append({
+                            "element_id": eid,
+                            "reason": "Tag failed: {}".format(str(tag_err)),
+                        })
+
+                t.Commit()
+
+                return routes.make_response(
+                    data={
+                        "status": "success",
+                        "tagged_count": len(tagged_ids),
+                        "tag_ids": tagged_ids,
+                        "skipped": skipped,
+                        "message": "Tagged {} element{}, {} skipped".format(
+                            len(tagged_ids),
+                            "s" if len(tagged_ids) != 1 else "",
+                            len(skipped),
+                        ),
+                    }
+                )
+
+            except Exception as tx_error:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                raise tx_error
+
+        except Exception as e:
+            logger.error("Failed to tag elements: {}".format(str(e)))
+            error_trace = traceback.format_exc()
+            return routes.make_response(
+                data={"error": str(e), "traceback": error_trace}, status=500
+            )
+
+    logger.info("Tag routes registered successfully")

--- a/revit_mcp/transforms.py
+++ b/revit_mcp/transforms.py
@@ -1,0 +1,203 @@
+# -*- coding: UTF-8 -*-
+"""
+Transforms Module for Revit MCP
+Handles move, copy, rotate, and mirror operations on elements
+"""
+
+from utils import get_element_id_value, make_element_id
+from pyrevit import routes, revit, DB
+from System.Collections.Generic import List
+import json
+import math
+import traceback
+import logging
+
+logger = logging.getLogger(__name__)
+
+MM_TO_FEET = 1.0 / 304.8
+
+
+def register_transform_routes(api):
+    """Register all transform routes with the API"""
+
+    @api.route("/transform_elements/", methods=["POST"])
+    def transform_elements_handler(doc, request):
+        """Move, copy, rotate, or mirror elements."""
+        try:
+            if not doc:
+                return routes.make_response(
+                    data={"error": "No active Revit document"}, status=503
+                )
+
+            data = json.loads(request.data) if isinstance(request.data, str) else request.data
+
+            element_ids = data.get("element_ids", [])
+            operation = data.get("operation")
+
+            if not element_ids:
+                return routes.make_response(
+                    data={"error": "element_ids is required and must not be empty"},
+                    status=400,
+                )
+            if not operation:
+                return routes.make_response(
+                    data={"error": "operation is required (move, copy, rotate, mirror)"},
+                    status=400,
+                )
+            if operation not in ("move", "copy", "rotate", "mirror"):
+                return routes.make_response(
+                    data={"error": "Invalid operation '{}'. Use: move, copy, rotate, mirror".format(operation)},
+                    status=400,
+                )
+
+            # Validate and collect elements
+            elem_id_list = []
+            for eid in element_ids:
+                elem_id = make_element_id(eid)
+                elem = doc.GetElement(elem_id)
+                if not elem:
+                    return routes.make_response(
+                        data={"error": "Element {} not found".format(eid)},
+                        status=404,
+                    )
+                # Check if pinned
+                if hasattr(elem, "Pinned") and elem.Pinned:
+                    return routes.make_response(
+                        data={"error": "Element {} is pinned — unpin it first using modify_element before transforming.".format(eid)},
+                        status=500,
+                    )
+                elem_id_list.append(elem_id)
+
+            t = DB.Transaction(doc, "Transform Elements via MCP")
+            t.Start()
+
+            try:
+                new_element_ids = []
+
+                if operation == "move":
+                    vector = data.get("vector")
+                    if not vector:
+                        t.RollBack()
+                        return routes.make_response(
+                            data={"error": "vector is required for move operation"},
+                            status=400,
+                        )
+                    translation = DB.XYZ(
+                        float(vector.get("x", 0)) * MM_TO_FEET,
+                        float(vector.get("y", 0)) * MM_TO_FEET,
+                        float(vector.get("z", 0)) * MM_TO_FEET,
+                    )
+                    for eid in elem_id_list:
+                        DB.ElementTransformUtils.MoveElement(doc, eid, translation)
+
+                elif operation == "copy":
+                    vector = data.get("vector")
+                    if not vector:
+                        t.RollBack()
+                        return routes.make_response(
+                            data={"error": "vector is required for copy operation"},
+                            status=400,
+                        )
+                    translation = DB.XYZ(
+                        float(vector.get("x", 0)) * MM_TO_FEET,
+                        float(vector.get("y", 0)) * MM_TO_FEET,
+                        float(vector.get("z", 0)) * MM_TO_FEET,
+                    )
+                    for eid in elem_id_list:
+                        copied = DB.ElementTransformUtils.CopyElement(
+                            doc, eid, translation
+                        )
+                        if copied:
+                            for cid in copied:
+                                new_element_ids.append(get_element_id_value(cid))
+
+                elif operation == "rotate":
+                    axis_point = data.get("axis_point")
+                    angle = data.get("angle")
+                    if not axis_point:
+                        t.RollBack()
+                        return routes.make_response(
+                            data={"error": "axis_point is required for rotate operation"},
+                            status=400,
+                        )
+                    if angle is None:
+                        t.RollBack()
+                        return routes.make_response(
+                            data={"error": "angle is required for rotate operation"},
+                            status=400,
+                        )
+
+                    center = DB.XYZ(
+                        float(axis_point.get("x", 0)) * MM_TO_FEET,
+                        float(axis_point.get("y", 0)) * MM_TO_FEET,
+                        float(axis_point.get("z", 0)) * MM_TO_FEET,
+                    )
+                    # Create vertical axis line through the point
+                    axis_line = DB.Line.CreateBound(
+                        center, DB.XYZ(center.X, center.Y, center.Z + 1.0)
+                    )
+                    angle_rad = float(angle) * math.pi / 180.0
+
+                    for eid in elem_id_list:
+                        DB.ElementTransformUtils.RotateElement(
+                            doc, eid, axis_line, angle_rad
+                        )
+
+                elif operation == "mirror":
+                    mirror_plane = data.get("mirror_plane")
+                    if not mirror_plane:
+                        t.RollBack()
+                        return routes.make_response(
+                            data={"error": "mirror_plane is required for mirror operation"},
+                            status=400,
+                        )
+
+                    origin = mirror_plane.get("origin", {})
+                    normal = mirror_plane.get("normal", {})
+
+                    plane_origin = DB.XYZ(
+                        float(origin.get("x", 0)) * MM_TO_FEET,
+                        float(origin.get("y", 0)) * MM_TO_FEET,
+                        float(origin.get("z", 0)) * MM_TO_FEET,
+                    )
+                    plane_normal = DB.XYZ(
+                        float(normal.get("x", 0)),
+                        float(normal.get("y", 1)),
+                        float(normal.get("z", 0)),
+                    ).Normalize()
+
+                    plane = DB.Plane.CreateByNormalAndOrigin(plane_normal, plane_origin)
+
+                    for eid in elem_id_list:
+                        DB.ElementTransformUtils.MirrorElement(doc, eid, plane)
+
+                t.Commit()
+
+                result = {
+                    "status": "success",
+                    "operation": operation,
+                    "count": len(elem_id_list),
+                    "message": "{} {} element{}".format(
+                        {"move": "Moved", "copy": "Copied", "rotate": "Rotated", "mirror": "Mirrored"}.get(operation, operation),
+                        len(elem_id_list),
+                        "s" if len(elem_id_list) != 1 else "",
+                    ),
+                }
+                if operation == "copy" and new_element_ids:
+                    result["new_element_ids"] = new_element_ids
+
+                return routes.make_response(data=result)
+
+            except Exception as tx_error:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                raise tx_error
+
+        except Exception as e:
+            logger.error("Failed to transform elements: {}".format(str(e)))
+            error_trace = traceback.format_exc()
+            return routes.make_response(
+                data={"error": str(e), "traceback": error_trace}, status=500
+            )
+
+    logger.info("Transform routes registered successfully")

--- a/revit_mcp/view_management.py
+++ b/revit_mcp/view_management.py
@@ -1,0 +1,370 @@
+# -*- coding: UTF-8 -*-
+"""
+View Management Module for Revit MCP
+Handles view creation and active view switching
+"""
+
+from utils import get_element_name, get_element_id_value
+from pyrevit import routes, revit, DB
+import json
+import traceback
+import logging
+
+logger = logging.getLogger(__name__)
+
+MM_TO_FEET = 1.0 / 304.8
+
+
+def register_view_management_routes(api):
+    """Register all view management routes with the API"""
+
+    @api.route("/create_view/", methods=["POST"])
+    def create_view_handler(doc, request):
+        """Create a new view in the Revit model."""
+        try:
+            if not doc:
+                return routes.make_response(
+                    data={"error": "No active Revit document"}, status=503
+                )
+
+            data = json.loads(request.data) if isinstance(request.data, str) else request.data
+
+            view_type = data.get("view_type")
+            name = data.get("name")
+
+            if not view_type:
+                return routes.make_response(
+                    data={"error": "view_type is required (floor_plan, ceiling_plan, section, elevation, 3d)"},
+                    status=400,
+                )
+            if not name:
+                return routes.make_response(
+                    data={"error": "name is required"}, status=400
+                )
+
+            level_name = data.get("level_name")
+
+            t = DB.Transaction(doc, "Create View via MCP")
+            t.Start()
+
+            try:
+                new_view = None
+
+                if view_type in ("floor_plan", "ceiling_plan"):
+                    if not level_name:
+                        t.RollBack()
+                        return routes.make_response(
+                            data={"error": "level_name is required for {} views".format(view_type)},
+                            status=400,
+                        )
+
+                    # Find the level
+                    levels = (
+                        DB.FilteredElementCollector(doc)
+                        .OfCategory(DB.BuiltInCategory.OST_Levels)
+                        .WhereElementIsNotElementType()
+                        .ToElements()
+                    )
+                    target_level = None
+                    for lv in levels:
+                        if get_element_name(lv) == level_name:
+                            target_level = lv
+                            break
+
+                    if not target_level:
+                        t.RollBack()
+                        available = [get_element_name(lv) for lv in levels]
+                        return routes.make_response(
+                            data={
+                                "error": "Level '{}' not found".format(level_name),
+                                "available_levels": available,
+                            },
+                            status=404,
+                        )
+
+                    # Find the appropriate view family type
+                    view_family_types = (
+                        DB.FilteredElementCollector(doc)
+                        .OfClass(DB.ViewFamilyType)
+                        .ToElements()
+                    )
+
+                    if view_type == "floor_plan":
+                        target_family = DB.ViewFamily.FloorPlan
+                    else:
+                        target_family = DB.ViewFamily.CeilingPlan
+
+                    vft = None
+                    for vf in view_family_types:
+                        if vf.ViewFamily == target_family:
+                            vft = vf
+                            break
+
+                    if not vft:
+                        t.RollBack()
+                        return routes.make_response(
+                            data={"error": "No {} view family type found in project".format(view_type)},
+                            status=500,
+                        )
+
+                    new_view = DB.ViewPlan.Create(doc, vft.Id, target_level.Id)
+
+                elif view_type == "section":
+                    section_box = data.get("section_box")
+                    if not section_box:
+                        t.RollBack()
+                        return routes.make_response(
+                            data={"error": "section_box is required for section views"},
+                            status=400,
+                        )
+
+                    # Find section view family type
+                    view_family_types = (
+                        DB.FilteredElementCollector(doc)
+                        .OfClass(DB.ViewFamilyType)
+                        .ToElements()
+                    )
+                    vft = None
+                    for vf in view_family_types:
+                        if vf.ViewFamily == DB.ViewFamily.Section:
+                            vft = vf
+                            break
+
+                    if not vft:
+                        t.RollBack()
+                        return routes.make_response(
+                            data={"error": "No section view family type found"},
+                            status=500,
+                        )
+
+                    # Build the section box transform
+                    origin = section_box.get("origin", {})
+                    direction = section_box.get("direction", {"x": 0, "y": 1, "z": 0})
+                    up = section_box.get("up", {"x": 0, "y": 0, "z": 1})
+                    width = float(section_box.get("width", 10000)) * MM_TO_FEET
+                    height = float(section_box.get("height", 10000)) * MM_TO_FEET
+                    depth = float(section_box.get("depth", 10000)) * MM_TO_FEET
+
+                    origin_pt = DB.XYZ(
+                        float(origin.get("x", 0)) * MM_TO_FEET,
+                        float(origin.get("y", 0)) * MM_TO_FEET,
+                        float(origin.get("z", 0)) * MM_TO_FEET,
+                    )
+                    dir_vec = DB.XYZ(
+                        float(direction.get("x", 0)),
+                        float(direction.get("y", 1)),
+                        float(direction.get("z", 0)),
+                    ).Normalize()
+                    up_vec = DB.XYZ(
+                        float(up.get("x", 0)),
+                        float(up.get("y", 0)),
+                        float(up.get("z", 1)),
+                    ).Normalize()
+
+                    # Right vector = direction cross up
+                    right_vec = dir_vec.CrossProduct(up_vec).Normalize()
+
+                    # Create transform
+                    transform = DB.Transform.Identity
+                    transform.Origin = origin_pt
+                    transform.BasisX = right_vec
+                    transform.BasisY = up_vec
+                    transform.BasisZ = dir_vec
+
+                    # Create bounding box for section
+                    section_bb = DB.BoundingBoxXYZ()
+                    section_bb.Transform = transform
+                    section_bb.Min = DB.XYZ(-width / 2.0, -height / 2.0, 0)
+                    section_bb.Max = DB.XYZ(width / 2.0, height / 2.0, depth)
+
+                    new_view = DB.ViewSection.CreateSection(doc, vft.Id, section_bb)
+
+                elif view_type == "3d":
+                    # Find 3D view family type
+                    view_family_types = (
+                        DB.FilteredElementCollector(doc)
+                        .OfClass(DB.ViewFamilyType)
+                        .ToElements()
+                    )
+                    vft = None
+                    for vf in view_family_types:
+                        if vf.ViewFamily == DB.ViewFamily.ThreeDimensional:
+                            vft = vf
+                            break
+
+                    if not vft:
+                        t.RollBack()
+                        return routes.make_response(
+                            data={"error": "No 3D view family type found"},
+                            status=500,
+                        )
+
+                    new_view = DB.View3D.CreateIsometric(doc, vft.Id)
+
+                elif view_type == "elevation":
+                    # Find elevation view family type
+                    view_family_types = (
+                        DB.FilteredElementCollector(doc)
+                        .OfClass(DB.ViewFamilyType)
+                        .ToElements()
+                    )
+                    vft = None
+                    for vf in view_family_types:
+                        if vf.ViewFamily == DB.ViewFamily.Elevation:
+                            vft = vf
+                            break
+
+                    if not vft:
+                        t.RollBack()
+                        return routes.make_response(
+                            data={"error": "No elevation view family type found"},
+                            status=500,
+                        )
+
+                    # Find a floor plan view to host the elevation marker
+                    elev_level = data.get("level_name")
+                    plan_view = None
+                    plan_views = (
+                        DB.FilteredElementCollector(doc)
+                        .OfClass(DB.ViewPlan)
+                        .WhereElementIsNotElementType()
+                        .ToElements()
+                    )
+                    # Try matching level first
+                    if elev_level:
+                        for pv in plan_views:
+                            if pv.ViewType == DB.ViewType.FloorPlan and not pv.IsTemplate:
+                                if pv.GenLevel and get_element_name(pv.GenLevel) == elev_level:
+                                    plan_view = pv
+                                    break
+                    # Fallback: active view if it's a plan
+                    if not plan_view:
+                        active = doc.ActiveView
+                        if hasattr(active, "ViewType") and active.ViewType == DB.ViewType.FloorPlan:
+                            plan_view = active
+                    # Fallback: any floor plan
+                    if not plan_view:
+                        for pv in plan_views:
+                            if pv.ViewType == DB.ViewType.FloorPlan and not pv.IsTemplate:
+                                plan_view = pv
+                                break
+
+                    if not plan_view:
+                        t.RollBack()
+                        return routes.make_response(
+                            data={"error": "No floor plan view found to host the elevation marker"},
+                            status=500,
+                        )
+
+                    # Create elevation marker at origin, then get the view
+                    marker = DB.ElevationMarker.CreateElevationMarker(
+                        doc, vft.Id, DB.XYZ.Zero, 1
+                    )
+                    new_view = marker.CreateElevation(doc, plan_view.Id, 0)
+
+                else:
+                    t.RollBack()
+                    return routes.make_response(
+                        data={"error": "Unsupported view_type '{}'. Use: floor_plan, ceiling_plan, section, elevation, 3d".format(view_type)},
+                        status=400,
+                    )
+
+                if new_view:
+                    new_view.Name = name
+
+                t.Commit()
+
+                actual_type = ""
+                try:
+                    actual_type = str(new_view.ViewType)
+                except Exception:
+                    actual_type = view_type
+
+                return routes.make_response(
+                    data={
+                        "status": "success",
+                        "view_id": get_element_id_value(new_view),
+                        "name": name,
+                        "view_type": actual_type,
+                        "message": "Created {} view '{}'".format(view_type, name),
+                    }
+                )
+
+            except Exception as tx_error:
+                if t.HasStarted() and not t.HasEnded():
+                    t.RollBack()
+                raise tx_error
+
+        except Exception as e:
+            logger.error("Failed to create view: {}".format(str(e)))
+            error_trace = traceback.format_exc()
+            return routes.make_response(
+                data={"error": str(e), "traceback": error_trace}, status=500
+            )
+
+    @api.route("/set_active_view/", methods=["POST"])
+    def set_active_view_handler(doc, uidoc, request):
+        """Set the active view in Revit UI."""
+        try:
+            if not doc:
+                return routes.make_response(
+                    data={"error": "No active Revit document"}, status=503
+                )
+
+            data = json.loads(request.data) if isinstance(request.data, str) else request.data
+
+            view_name = data.get("view_name")
+            if not view_name:
+                return routes.make_response(
+                    data={"error": "view_name is required"}, status=400
+                )
+
+            # Find the view
+            views = (
+                DB.FilteredElementCollector(doc)
+                .OfClass(DB.View)
+                .WhereElementIsNotElementType()
+                .ToElements()
+            )
+
+            target_view = None
+            available_views = []
+            for v in views:
+                try:
+                    vname = get_element_name(v)
+                    if not v.IsTemplate:
+                        available_views.append(vname)
+                    if vname == view_name and not v.IsTemplate:
+                        target_view = v
+                except Exception:
+                    continue
+
+            if not target_view:
+                return routes.make_response(
+                    data={
+                        "error": "View '{}' not found".format(view_name),
+                        "available_views": sorted(available_views)[:30],
+                    },
+                    status=404,
+                )
+
+            uidoc.ActiveView = target_view
+
+            return routes.make_response(
+                data={
+                    "status": "success",
+                    "view_id": get_element_id_value(target_view),
+                    "name": view_name,
+                    "view_type": str(target_view.ViewType),
+                    "message": "Switched to view '{}'".format(view_name),
+                }
+            )
+
+        except Exception as e:
+            logger.error("Failed to set active view: {}".format(str(e)))
+            error_trace = traceback.format_exc()
+            return routes.make_response(
+                data={"error": str(e), "traceback": error_trace}, status=500
+            )
+
+    logger.info("View management routes registered successfully")

--- a/startup.py
+++ b/startup.py
@@ -92,6 +92,9 @@ def register_routes():
         from revit_mcp.detailing import register_detailing_routes
         register_detailing_routes(api)
 
+        from revit_mcp.rvt_extras import register_rvt_extras_routes
+        register_rvt_extras_routes(api)
+
         logger.info("All MCP routes registered successfully")
 
     except Exception as e:

--- a/startup.py
+++ b/startup.py
@@ -65,6 +65,24 @@ def register_routes():
 
         register_ported_annotation_routes(api)
 
+        # --- Upstream (revit-mcp-server) route modules merged in ---
+        from revit_mcp.mep import register_mep_routes
+        register_mep_routes(api)
+        from revit_mcp.detail import register_detail_routes
+        register_detail_routes(api)
+        from revit_mcp.transforms import register_transform_routes
+        register_transform_routes(api)
+        from revit_mcp.interop import register_interop_routes
+        register_interop_routes(api)
+        from revit_mcp.parameters import register_parameter_routes
+        register_parameter_routes(api)
+        from revit_mcp.view_management import register_view_management_routes
+        register_view_management_routes(api)
+        from revit_mcp.tags import register_tag_routes
+        register_tag_routes(api)
+        from revit_mcp.structure import register_structure_routes
+        register_structure_routes(api)
+
         logger.info("All MCP routes registered successfully")
 
     except Exception as e:

--- a/startup.py
+++ b/startup.py
@@ -86,6 +86,12 @@ def register_routes():
         from revit_mcp.shared_params import register_shared_param_routes
         register_shared_param_routes(api)
 
+        from revit_mcp.geometry import register_geometry_routes
+        register_geometry_routes(api)
+
+        from revit_mcp.detailing import register_detailing_routes
+        register_detailing_routes(api)
+
         logger.info("All MCP routes registered successfully")
 
     except Exception as e:

--- a/startup.py
+++ b/startup.py
@@ -61,6 +61,10 @@ def register_routes():
 
         register_ported_ops_routes(api)
 
+        from revit_mcp.ported_annotation import register_ported_annotation_routes
+
+        register_ported_annotation_routes(api)
+
         logger.info("All MCP routes registered successfully")
 
     except Exception as e:

--- a/startup.py
+++ b/startup.py
@@ -83,6 +83,9 @@ def register_routes():
         from revit_mcp.structure import register_structure_routes
         register_structure_routes(api)
 
+        from revit_mcp.shared_params import register_shared_param_routes
+        register_shared_param_routes(api)
+
         logger.info("All MCP routes registered successfully")
 
     except Exception as e:

--- a/startup.py
+++ b/startup.py
@@ -45,6 +45,10 @@ def register_routes():
 
         register_document_routes(api)
 
+        from revit_mcp.structure_framing import register_structure_framing_routes
+
+        register_structure_framing_routes(api)
+
         logger.info("All MCP routes registered successfully")
 
     except Exception as e:

--- a/startup.py
+++ b/startup.py
@@ -49,6 +49,18 @@ def register_routes():
 
         register_structure_framing_routes(api)
 
+        from revit_mcp.ported_query import register_ported_query_routes
+
+        register_ported_query_routes(api)
+
+        from revit_mcp.ported_create import register_ported_create_routes
+
+        register_ported_create_routes(api)
+
+        from revit_mcp.ported_ops import register_ported_ops_routes
+
+        register_ported_ops_routes(api)
+
         logger.info("All MCP routes registered successfully")
 
     except Exception as e:

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -14,6 +14,9 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     from .launch_tools import register_launch_tools
     from .document_tools import register_document_tools
     from .structure_tools import register_structure_tools
+    from .query_tools import register_query_tools
+    from .create_tools import register_create_tools
+    from .ops_tools import register_ops_tools
 
     # Register tools from each module
     register_status_tools(mcp_server, revit_get_func)
@@ -27,3 +30,6 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     register_launch_tools(mcp_server, revit_get_func)
     register_document_tools(mcp_server, revit_get_func, revit_post_func)
     register_structure_tools(mcp_server, revit_get_func, revit_post_func)
+    register_query_tools(mcp_server, revit_get_func, revit_post_func)
+    register_create_tools(mcp_server, revit_get_func, revit_post_func)
+    register_ops_tools(mcp_server, revit_get_func, revit_post_func)

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -29,6 +29,7 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     from .shared_param_tools import register_shared_param_tools
     from .geometry_tools import register_geometry_tools
     from .detailing_tools import register_detailing_tools
+    from .rvt_extras_tools import register_rvt_extras_tools
 
     # Register tools from each module
     register_status_tools(mcp_server, revit_get_func)
@@ -57,3 +58,4 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     register_shared_param_tools(mcp_server, revit_get_func, revit_post_func)
     register_geometry_tools(mcp_server, revit_get_func, revit_post_func)
     register_detailing_tools(mcp_server, revit_get_func, revit_post_func)
+    register_rvt_extras_tools(mcp_server, revit_get_func, revit_post_func)

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -27,6 +27,8 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     from .tag_tools import register_tag_tools
     from .upstream_structure_tools import register_upstream_structure_tools
     from .shared_param_tools import register_shared_param_tools
+    from .geometry_tools import register_geometry_tools
+    from .detailing_tools import register_detailing_tools
 
     # Register tools from each module
     register_status_tools(mcp_server, revit_get_func)
@@ -53,3 +55,5 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     register_tag_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func)
     register_upstream_structure_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func)
     register_shared_param_tools(mcp_server, revit_get_func, revit_post_func)
+    register_geometry_tools(mcp_server, revit_get_func, revit_post_func)
+    register_detailing_tools(mcp_server, revit_get_func, revit_post_func)

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -17,6 +17,7 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     from .query_tools import register_query_tools
     from .create_tools import register_create_tools
     from .ops_tools import register_ops_tools
+    from .annotation_tools import register_annotation_tools
 
     # Register tools from each module
     register_status_tools(mcp_server, revit_get_func)
@@ -33,3 +34,4 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     register_query_tools(mcp_server, revit_get_func, revit_post_func)
     register_create_tools(mcp_server, revit_get_func, revit_post_func)
     register_ops_tools(mcp_server, revit_get_func, revit_post_func)
+    register_annotation_tools(mcp_server, revit_get_func, revit_post_func)

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -18,6 +18,14 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     from .create_tools import register_create_tools
     from .ops_tools import register_ops_tools
     from .annotation_tools import register_annotation_tools
+    from .mep_tools import register_mep_tools
+    from .detail_tools import register_detail_tools
+    from .transform_tools import register_transform_tools
+    from .interop_tools import register_interop_tools
+    from .parameter_tools import register_parameter_tools
+    from .view_management_tools import register_view_management_tools
+    from .tag_tools import register_tag_tools
+    from .upstream_structure_tools import register_upstream_structure_tools
 
     # Register tools from each module
     register_status_tools(mcp_server, revit_get_func)
@@ -35,3 +43,11 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     register_create_tools(mcp_server, revit_get_func, revit_post_func)
     register_ops_tools(mcp_server, revit_get_func, revit_post_func)
     register_annotation_tools(mcp_server, revit_get_func, revit_post_func)
+    register_mep_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func)
+    register_detail_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func)
+    register_transform_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func)
+    register_interop_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func)
+    register_parameter_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func)
+    register_view_management_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func)
+    register_tag_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func)
+    register_upstream_structure_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func)

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -13,6 +13,7 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     from .code_execution_tools import register_code_execution_tools
     from .launch_tools import register_launch_tools
     from .document_tools import register_document_tools
+    from .structure_tools import register_structure_tools
 
     # Register tools from each module
     register_status_tools(mcp_server, revit_get_func)
@@ -25,3 +26,4 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     )
     register_launch_tools(mcp_server, revit_get_func)
     register_document_tools(mcp_server, revit_get_func, revit_post_func)
+    register_structure_tools(mcp_server, revit_get_func, revit_post_func)

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -26,6 +26,7 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     from .view_management_tools import register_view_management_tools
     from .tag_tools import register_tag_tools
     from .upstream_structure_tools import register_upstream_structure_tools
+    from .shared_param_tools import register_shared_param_tools
 
     # Register tools from each module
     register_status_tools(mcp_server, revit_get_func)
@@ -51,3 +52,4 @@ def register_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func
     register_view_management_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func)
     register_tag_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func)
     register_upstream_structure_tools(mcp_server, revit_get_func, revit_post_func, revit_image_func)
+    register_shared_param_tools(mcp_server, revit_get_func, revit_post_func)

--- a/tools/annotation_tools.py
+++ b/tools/annotation_tools.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+"""Annotation/misc tools ported from the mcp-servers-for-revit C# command set."""
+
+from mcp.server.fastmcp import Context
+from typing import List, Dict, Any
+from .utils import format_response
+
+
+def register_annotation_tools(mcp, revit_get, revit_post):
+
+    @mcp.tool()
+    async def create_dimensions(
+        view_name: str = None,
+        dimensions: List[Dict[str, Any]] = None,
+        element_ids: List[int] = None,
+        line: Dict[str, Any] = None,
+        ctx: Context = None,
+    ) -> str:
+        """
+        Create linear dimensions referencing elements (e.g. grids).
+        Provide either `dimensions` (a list of {element_ids, line}) or a single
+        `element_ids` + `line`. line = {"p0":{"x","y","z"},"p1":{"x","y","z"}} (feet);
+        the dimension string is placed along p0->p1.
+        """
+        data = {}
+        if view_name:
+            data["view_name"] = view_name
+        if dimensions:
+            data["dimensions"] = dimensions
+        if element_ids:
+            data["element_ids"] = element_ids
+        if line:
+            data["line"] = line
+        return format_response(await revit_post("/create_dimensions/", data, ctx))
+
+    @mcp.tool()
+    async def create_levels(levels: List[Dict[str, Any]], ctx: Context = None) -> str:
+        """Create new levels. levels=[{"name":"3rd Level","elevation":31.33}] (feet)."""
+        return format_response(await revit_post("/create_levels/", {"levels": levels}, ctx))
+
+    @mcp.tool()
+    async def export_room_data(ctx: Context = None) -> str:
+        """Export all rooms with name, number, area, level, and comments."""
+        return format_response(await revit_get("/export_room_data/", ctx))
+
+    @mcp.tool()
+    async def say_hello(ctx: Context = None) -> str:
+        """Connection test: greeting + active document/view info."""
+        return format_response(await revit_get("/say_hello/", ctx))

--- a/tools/create_tools.py
+++ b/tools/create_tools.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+"""Element creation tools ported from tools/create_*.ts. Units are FEET."""
+
+from mcp.server.fastmcp import Context
+from typing import List, Dict, Any
+from .utils import format_response
+
+
+def register_create_tools(mcp, revit_get, revit_post):
+
+    @mcp.tool()
+    async def create_point_based_element(data: List[Dict[str, Any]], ctx: Context = None) -> str:
+        """
+        Batch-create point-based family instances (doors, windows, furniture, equipment).
+        data: [{"name":"...", "family":"...", "type":"..." (or "typeId":int),
+                "locationPoint":{"x":..,"y":..,"z":..}, "level":"Level 1", "rotation":0}]  (feet, deg)
+        """
+        return format_response(await revit_post("/create_point_based_element/", {"data": data}, ctx))
+
+    @mcp.tool()
+    async def create_line_based_element(data: List[Dict[str, Any]], ctx: Context = None) -> str:
+        """
+        Batch-create line-based elements (walls via WallType, or framing via a FamilySymbol).
+        data: [{"name":"...", "family":"...", "type":"..." (or "typeId":int),
+                "locationLine":{"p0":{x,y,z},"p1":{x,y,z}}, "height":.., "baseOffset":.., "level":".."}]  (feet)
+        """
+        return format_response(await revit_post("/create_line_based_element/", {"data": data}, ctx))
+
+    @mcp.tool()
+    async def create_surface_based_element(data: List[Dict[str, Any]], ctx: Context = None) -> str:
+        """
+        Batch-create floors from a boundary loop.
+        data: [{"name":"...", "family":"...", "type":"..." (or "typeId":int),
+                "boundary":{"outerLoop":[{"p0":{x,y,z},"p1":{x,y,z}}, ...]}, "level":"..", "baseOffset":..}]  (feet)
+        """
+        return format_response(await revit_post("/create_surface_based_element/", {"data": data}, ctx))
+
+    @mcp.tool()
+    async def create_room(data: List[Dict[str, Any]], ctx: Context = None) -> str:
+        """
+        Create rooms at points. data: [{"level":"Level 1","x":..,"y":..,"name":"OFFICE","number":"200"}]  (feet)
+        """
+        return format_response(await revit_post("/create_room/", {"data": data}, ctx))

--- a/tools/detail_tools.py
+++ b/tools/detail_tools.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+"""Detail tools — detail lines for view-specific annotation"""
+
+from mcp.server.fastmcp import Context
+from .utils import format_response
+
+
+def register_detail_tools(mcp, revit_get, revit_post, revit_image=None):
+    """Register detail tools with the MCP server."""
+    _ = revit_image  # Acknowledge unused parameter
+
+    @mcp.tool()
+    async def create_detail_line(
+        start_point: dict,
+        end_point: dict,
+        view_name: str = None,
+        line_style: str = None,
+        ctx: Context = None,
+    ) -> str:
+        """Create a detail line in a Revit view for annotation purposes.
+
+        Detail lines are view-specific 2D annotation elements. They only
+        appear in the view where they are created (unlike model lines).
+        Must be created in a plan, section, or detail view.
+
+        Args:
+            start_point: Start point {"x", "y", "z"} in mm
+            end_point: End point {"x", "y", "z"} in mm
+            view_name: Target view name (defaults to active view)
+            line_style: Line style name (e.g., "Medium Lines"). Uses default if omitted
+            ctx: MCP context for logging
+        """
+        data = {"start_point": start_point, "end_point": end_point}
+        if view_name is not None:
+            data["view_name"] = view_name
+        if line_style is not None:
+            data["line_style"] = line_style
+        response = await revit_post("/create_detail_line/", data, ctx)
+        return format_response(response)

--- a/tools/detailing_tools.py
+++ b/tools/detailing_tools.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+"""2D detailing tools: markups, detail/model/symbolic shapes, detail components,
+filled & masking regions. Units in FEET, angles in DEGREES."""
+
+from mcp.server.fastmcp import Context
+from typing import List, Dict, Any
+from .utils import format_response
+
+
+def register_detailing_tools(mcp, revit_get, revit_post):
+
+    @mcp.tool()
+    async def create_point_markup(points: List[Dict[str, float]], markup_type: str = "cross",
+                                  size: float = 1.0, ctx: Context = None) -> str:
+        """Create detail markups (cross | circle | square) at points in the active view."""
+        return format_response(await revit_post("/create_point_markup/",
+                               {"points": points, "markup_type": markup_type, "size": size}, ctx))
+
+    @mcp.tool()
+    async def create_detail_shapes(shape_type: str, center_x: float = 0, center_y: float = 0,
+                                   width: float = 5, height: float = 5, radius: float = 5,
+                                   sides: int = 6, rotation: float = 0, view_name: str = None, ctx: Context = None) -> str:
+        """Draw a 2D shape (rectangle | circle | polygon) as detail lines in a view."""
+        d = {"shape_type": shape_type, "center_x": center_x, "center_y": center_y, "width": width,
+             "height": height, "radius": radius, "sides": sides, "rotation": rotation}
+        if view_name: d["view_name"] = view_name
+        return format_response(await revit_post("/create_detail_shapes/", d, ctx))
+
+    @mcp.tool()
+    async def create_model_shapes(shape_type: str, center_x: float = 0, center_y: float = 0, center_z: float = 0,
+                                  width: float = 5, height: float = 5, radius: float = 5,
+                                  sides: int = 6, rotation: float = 0, ctx: Context = None) -> str:
+        """Draw a 2D shape as model lines in 3D space."""
+        return format_response(await revit_post("/create_model_shapes/",
+                               {"shape_type": shape_type, "center_x": center_x, "center_y": center_y,
+                                "center_z": center_z, "width": width, "height": height, "radius": radius,
+                                "sides": sides, "rotation": rotation}, ctx))
+
+    @mcp.tool()
+    async def create_symbolic_shapes(shape_type: str, center_x: float = 0, center_y: float = 0,
+                                     width: float = 5, height: float = 5, radius: float = 5,
+                                     sides: int = 6, rotation: float = 0, ctx: Context = None) -> str:
+        """Draw a 2D shape as symbolic lines (family document only)."""
+        return format_response(await revit_post("/create_symbolic_shapes/",
+                               {"shape_type": shape_type, "center_x": center_x, "center_y": center_y,
+                                "width": width, "height": height, "radius": radius,
+                                "sides": sides, "rotation": rotation}, ctx))
+
+    @mcp.tool()
+    async def place_detail_component(family: str, type: str, x: float, y: float,
+                                     view_name: str = None, rotation: float = 0, ctx: Context = None) -> str:
+        """Place a 2D detail-component family instance in a detail/drafting view (feet, degrees)."""
+        d = {"family": family, "type": type, "x": x, "y": y, "rotation": rotation}
+        if view_name: d["view_name"] = view_name
+        return format_response(await revit_post("/place_detail_component/", d, ctx))
+
+    @mcp.tool()
+    async def create_filled_region(boundary: List[Dict[str, float]], view_name: str = None,
+                                   type_name: str = None, ctx: Context = None) -> str:
+        """Create a filled region from a closed boundary loop of points (feet)."""
+        d = {"boundary": boundary}
+        if view_name: d["view_name"] = view_name
+        if type_name: d["type_name"] = type_name
+        return format_response(await revit_post("/create_filled_region/", d, ctx))
+
+    @mcp.tool()
+    async def create_masking_region(boundary: List[Dict[str, float]], view_name: str = None, ctx: Context = None) -> str:
+        """Create a masking region from a closed boundary loop of points (feet)."""
+        d = {"boundary": boundary}
+        if view_name: d["view_name"] = view_name
+        return format_response(await revit_post("/create_masking_region/", d, ctx))

--- a/tools/geometry_tools.py
+++ b/tools/geometry_tools.py
@@ -1,0 +1,154 @@
+# -*- coding: utf-8 -*-
+"""Geometry tools (curves, splines, arcs, points, transforms, curve math).
+Ported from Revit-2026-MCP-Server. Units in FEET, angles in DEGREES."""
+
+from mcp.server.fastmcp import Context
+from typing import List, Dict, Any
+from .utils import format_response
+
+
+def register_geometry_tools(mcp, revit_get, revit_post):
+    P = lambda path, data, ctx: revit_post(path, data, ctx)
+
+    @mcp.tool()
+    async def create_bounded_line(start: Dict[str, float], end: Dict[str, float], ctx: Context = None) -> str:
+        """Create a model line between two points (feet)."""
+        return format_response(await revit_post("/create_bounded_line/", {"start": start, "end": end}, ctx))
+
+    @mcp.tool()
+    async def create_curves_from_points(points: List[Dict[str, float]], closed: bool = False, ctx: Context = None) -> str:
+        """Create connected model lines through a list of points."""
+        return format_response(await revit_post("/create_curves_from_points/", {"points": points, "closed": closed}, ctx))
+
+    @mcp.tool()
+    async def create_hermite_spline(points: List[Dict[str, float]], closed: bool = False, ctx: Context = None) -> str:
+        """Create a Hermite spline model curve through points (for curved steel/concrete/sweeps)."""
+        return format_response(await revit_post("/create_hermite_spline/", {"points": points, "closed": closed}, ctx))
+
+    @mcp.tool()
+    async def create_hermite_spline_with_tangents(points: List[Dict[str, float]], start_tangent: Dict[str, float],
+                                                  end_tangent: Dict[str, float], closed: bool = False, ctx: Context = None) -> str:
+        """Hermite spline with specified end tangents."""
+        return format_response(await revit_post("/create_hermite_spline_with_tangents/",
+                               {"points": points, "start_tangent": start_tangent, "end_tangent": end_tangent, "closed": closed}, ctx))
+
+    @mcp.tool()
+    async def create_offset_curve(curve_element_id: int, offset: float, normal: Dict[str, float] = None, ctx: Context = None) -> str:
+        """Offset an existing curve element by `offset` feet (normal defaults to Z)."""
+        d = {"curve_element_id": curve_element_id, "offset": offset}
+        if normal: d["normal"] = normal
+        return format_response(await revit_post("/create_offset_curve/", d, ctx))
+
+    @mcp.tool()
+    async def create_clone_curve(curve_element_id: int, ctx: Context = None) -> str:
+        """Clone a curve element."""
+        return format_response(await revit_post("/create_clone_curve/", {"curve_element_id": curve_element_id}, ctx))
+
+    @mcp.tool()
+    async def create_grid_line(start: Dict[str, float], end: Dict[str, float], name: str = None, ctx: Context = None) -> str:
+        """Create a straight grid from two points."""
+        d = {"start": start, "end": end}
+        if name: d["name"] = name
+        return format_response(await revit_post("/create_grid_line/", d, ctx))
+
+    @mcp.tool()
+    async def create_grid_arc(center: Dict[str, float], radius: float, start_angle: float = 0,
+                              end_angle: float = 90, name: str = None, ctx: Context = None) -> str:
+        """Create a curved (radial/arc) grid — for round/curved building layouts."""
+        d = {"center": center, "radius": radius, "start_angle": start_angle, "end_angle": end_angle}
+        if name: d["name"] = name
+        return format_response(await revit_post("/create_grid_arc/", d, ctx))
+
+    @mcp.tool()
+    async def create_point(x: float, y: float, z: float = 0.0, ctx: Context = None) -> str:
+        """Create a reference point (family docs) or echo coordinates (projects)."""
+        return format_response(await revit_post("/create_point/", {"x": x, "y": y, "z": z}, ctx))
+
+    @mcp.tool()
+    async def create_point_on_element(element_id: int, point: Dict[str, float], ctx: Context = None) -> str:
+        """Project a point onto an element's geometry; returns nearest point + a face Reference (for hosting/dimensioning)."""
+        return format_response(await revit_post("/create_point_on_element/", {"element_id": element_id, "point": point}, ctx))
+
+    @mcp.tool()
+    async def calculate_line_direction(start: Dict[str, float], end: Dict[str, float], ctx: Context = None) -> str:
+        """Return the normalized direction and length between two points."""
+        return format_response(await revit_post("/calculate_line_direction/", {"start": start, "end": end}, ctx))
+
+    @mcp.tool()
+    async def rotate_elements(element_ids: List[int], angle: float, axis_point: Dict[str, float] = None,
+                              axis_dir: Dict[str, float] = None, ctx: Context = None) -> str:
+        """Rotate elements by `angle` degrees about an axis (defaults to Z through the origin)."""
+        d = {"element_ids": element_ids, "angle": angle}
+        if axis_point: d["axis_point"] = axis_point
+        if axis_dir: d["axis_dir"] = axis_dir
+        return format_response(await revit_post("/rotate_elements/", d, ctx))
+
+    @mcp.tool()
+    async def evaluate_curve(curve_element_id: int, parameter: float, normalized: bool = False, ctx: Context = None) -> str:
+        """Point on a curve element at a parameter (normalized 0-1 if normalized=true)."""
+        return format_response(await revit_post("/evaluate_curve/", {"curve_element_id": curve_element_id, "parameter": parameter, "normalized": normalized}, ctx))
+
+    @mcp.tool()
+    async def curve_distance_to_point(curve_element_id: int, point: Dict[str, float], ctx: Context = None) -> str:
+        """Shortest distance from a point to a curve element."""
+        return format_response(await revit_post("/curve_distance_to_point/", {"curve_element_id": curve_element_id, "point": point}, ctx))
+
+    @mcp.tool()
+    async def curve_get_end_point(curve_element_id: int, end: int = 0, ctx: Context = None) -> str:
+        """Start (0) or end (1) point of a curve element."""
+        return format_response(await revit_post("/curve_get_end_point/", {"curve_element_id": curve_element_id, "end": end}, ctx))
+
+    @mcp.tool()
+    async def curve_get_end_parameter(curve_element_id: int, end: int = 0, ctx: Context = None) -> str:
+        """Raw parameter at the start/end of a curve element."""
+        return format_response(await revit_post("/curve_get_end_parameter/", {"curve_element_id": curve_element_id, "end": end}, ctx))
+
+    @mcp.tool()
+    async def curve_get_end_point_reference(curve_element_id: int, end: int = 0, ctx: Context = None) -> str:
+        """Stable Reference to a curve endpoint (for dimensioning/constraints)."""
+        return format_response(await revit_post("/curve_get_end_point_reference/", {"curve_element_id": curve_element_id, "end": end}, ctx))
+
+    @mcp.tool()
+    async def curve_compute_derivatives(curve_element_id: int, parameter: float, normalized: bool = False, ctx: Context = None) -> str:
+        """Origin + 1st/2nd derivative vectors of a curve at a parameter."""
+        return format_response(await revit_post("/curve_compute_derivatives/", {"curve_element_id": curve_element_id, "parameter": parameter, "normalized": normalized}, ctx))
+
+    @mcp.tool()
+    async def curve_compute_normalized_parameter(curve_element_id: int, raw_parameter: float, ctx: Context = None) -> str:
+        """Convert a raw parameter to normalized (0-1)."""
+        return format_response(await revit_post("/curve_compute_normalized_parameter/", {"curve_element_id": curve_element_id, "raw_parameter": raw_parameter}, ctx))
+
+    @mcp.tool()
+    async def curve_compute_raw_parameter(curve_element_id: int, normalized_parameter: float, ctx: Context = None) -> str:
+        """Convert a normalized parameter (0-1) to raw."""
+        return format_response(await revit_post("/curve_compute_raw_parameter/", {"curve_element_id": curve_element_id, "normalized_parameter": normalized_parameter}, ctx))
+
+    @mcp.tool()
+    async def curve_point_location_on_curve(curve_element_id: int, point: Dict[str, float], ctx: Context = None) -> str:
+        """Project a point onto a curve element; returns point, parameter, distance."""
+        return format_response(await revit_post("/curve_point_location_on_curve/", {"curve_element_id": curve_element_id, "point": point}, ctx))
+
+    @mcp.tool()
+    async def curve_compute_closest_points(curve_element_id_a: int, curve_element_id_b: int, ctx: Context = None) -> str:
+        """Closest approach between two curve elements (point pair + distance)."""
+        return format_response(await revit_post("/curve_compute_closest_points/", {"curve_element_id_a": curve_element_id_a, "curve_element_id_b": curve_element_id_b}, ctx))
+
+    @mcp.tool()
+    async def curve_create_reversed(curve_element_id: int, ctx: Context = None) -> str:
+        """Create a new curve element with reversed direction."""
+        return format_response(await revit_post("/curve_create_reversed/", {"curve_element_id": curve_element_id}, ctx))
+
+    @mcp.tool()
+    async def curve_create_transformed(curve_element_id: int, translation: Dict[str, float] = None, rotation_deg: float = 0,
+                                       axis_point: Dict[str, float] = None, axis_dir: Dict[str, float] = None, ctx: Context = None) -> str:
+        """Create a new curve element transformed by a translation and/or rotation."""
+        d = {"curve_element_id": curve_element_id, "rotation_deg": rotation_deg}
+        if translation: d["translation"] = translation
+        if axis_point: d["axis_point"] = axis_point
+        if axis_dir: d["axis_dir"] = axis_dir
+        return format_response(await revit_post("/curve_create_transformed/", d, ctx))
+
+    @mcp.tool()
+    async def curve_intersect(curve_element_id_a: int, curve_element_id_b: int, ctx: Context = None) -> str:
+        """Intersect two curve elements; returns the comparison result and any intersection points."""
+        return format_response(await revit_post("/curve_intersect/", {"curve_element_id_a": curve_element_id_a, "curve_element_id_b": curve_element_id_b}, ctx))

--- a/tools/interop_tools.py
+++ b/tools/interop_tools.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+"""Interop tools — IFC export and external file linking"""
+
+from mcp.server.fastmcp import Context
+from .utils import format_response
+
+
+def register_interop_tools(mcp, revit_get, revit_post, revit_image=None):
+    """Register interop tools with the MCP server."""
+    _ = revit_image  # Acknowledge unused parameter
+
+    @mcp.tool()
+    async def export_ifc(
+        file_path: str,
+        ifc_version: str = "IFC2x3",
+        export_base_quantities: bool = True,
+        view_name: str = None,
+        ctx: Context = None,
+    ) -> str:
+        """Export the Revit model to IFC format.
+
+        Creates an IFC file at the specified path. Optionally filter by view
+        to export only visible elements. Supports IFC2x3 and IFC4.
+
+        Args:
+            file_path: Output file path (must end in .ifc)
+            ifc_version: "IFC2x3" (default) or "IFC4"
+            export_base_quantities: Include IFC base quantities (default: true)
+            view_name: Export only elements visible in this view (optional)
+            ctx: MCP context for logging
+        """
+        data = {
+            "file_path": file_path,
+            "ifc_version": ifc_version,
+            "export_base_quantities": export_base_quantities,
+        }
+        if view_name is not None:
+            data["view_name"] = view_name
+        response = await revit_post("/export_ifc/", data, ctx)
+        return format_response(response)
+
+    @mcp.tool()
+    async def link_file(
+        file_path: str,
+        mode: str = "link",
+        position: dict = None,
+        ctx: Context = None,
+    ) -> str:
+        """Link or import an external file into the Revit model.
+
+        Supports DWG, DXF, DGN (CAD files) and RVT (Revit links).
+        Linked files maintain a live connection; imported files are embedded.
+
+        Args:
+            file_path: Path to the file (DWG, DXF, DGN, or RVT)
+            mode: "link" (default, maintains connection) or "import" (embeds copy)
+            position: Optional placement offset {"x", "y", "z"} in mm
+            ctx: MCP context for logging
+        """
+        data = {"file_path": file_path, "mode": mode}
+        if position is not None:
+            data["position"] = position
+        response = await revit_post("/link_file/", data, ctx)
+        return format_response(response)

--- a/tools/mep_tools.py
+++ b/tools/mep_tools.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+"""MEP tools — ducts, pipes, and mechanical/plumbing systems"""
+
+from mcp.server.fastmcp import Context
+from .utils import format_response
+
+
+def register_mep_tools(mcp, revit_get, revit_post, revit_image=None):
+    """Register MEP tools with the MCP server."""
+    _ = revit_image  # Acknowledge unused parameter
+
+    @mcp.tool()
+    async def create_duct(
+        start_point: dict,
+        end_point: dict,
+        system_type: str = None,
+        duct_type: str = None,
+        level_name: str = None,
+        diameter: float = None,
+        width: float = None,
+        height: float = None,
+        ctx: Context = None,
+    ) -> str:
+        """Create a duct in the Revit model between two points.
+
+        Requires a project with mechanical families loaded (MEP template).
+        Specify diameter for round ducts, or width+height for rectangular.
+        All dimensions in millimeters.
+
+        Args:
+            start_point: Start point {"x", "y", "z"} in mm
+            end_point: End point {"x", "y", "z"} in mm
+            system_type: System type name (e.g., "Supply Air"). Auto-detects if omitted
+            duct_type: Duct type name (e.g., "Round Duct"). Auto-detects if omitted
+            level_name: Level name. Defaults to nearest level
+            diameter: Round duct diameter in mm
+            width: Rectangular duct width in mm
+            height: Rectangular duct height in mm
+            ctx: MCP context for logging
+        """
+        data = {"start_point": start_point, "end_point": end_point}
+        if system_type is not None:
+            data["system_type"] = system_type
+        if duct_type is not None:
+            data["duct_type"] = duct_type
+        if level_name is not None:
+            data["level_name"] = level_name
+        if diameter is not None:
+            data["diameter"] = diameter
+        if width is not None:
+            data["width"] = width
+        if height is not None:
+            data["height"] = height
+        response = await revit_post("/create_duct/", data, ctx)
+        return format_response(response)
+
+    @mcp.tool()
+    async def create_pipe(
+        start_point: dict,
+        end_point: dict,
+        system_type: str = None,
+        pipe_type: str = None,
+        level_name: str = None,
+        diameter: float = None,
+        ctx: Context = None,
+    ) -> str:
+        """Create a pipe in the Revit model between two points.
+
+        Requires a project with plumbing families loaded (MEP template).
+        All dimensions in millimeters.
+
+        Args:
+            start_point: Start point {"x", "y", "z"} in mm
+            end_point: End point {"x", "y", "z"} in mm
+            system_type: System type name (e.g., "Domestic Hot Water"). Auto-detects if omitted
+            pipe_type: Pipe type name (e.g., "Copper"). Auto-detects if omitted
+            level_name: Level name. Defaults to nearest level
+            diameter: Pipe diameter in mm
+            ctx: MCP context for logging
+        """
+        data = {"start_point": start_point, "end_point": end_point}
+        if system_type is not None:
+            data["system_type"] = system_type
+        if pipe_type is not None:
+            data["pipe_type"] = pipe_type
+        if level_name is not None:
+            data["level_name"] = level_name
+        if diameter is not None:
+            data["diameter"] = diameter
+        response = await revit_post("/create_pipe/", data, ctx)
+        return format_response(response)
+
+    @mcp.tool()
+    async def create_mep_system(
+        system_type: str,
+        system_name: str,
+        element_ids: list[int] = None,
+        ctx: Context = None,
+    ) -> str:
+        """Create a mechanical or piping system and optionally add elements to it.
+
+        Groups ducts or pipes into a named system for organization and analysis.
+
+        Args:
+            system_type: "mechanical" or "piping"
+            system_name: Display name for the system (e.g., "Level 1 Supply Air")
+            element_ids: Optional list of duct/pipe element IDs to add to the system
+            ctx: MCP context for logging
+        """
+        data = {"system_type": system_type, "system_name": system_name}
+        if element_ids is not None:
+            data["element_ids"] = element_ids
+        response = await revit_post("/create_mep_system/", data, ctx)
+        return format_response(response)

--- a/tools/ops_tools.py
+++ b/tools/ops_tools.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+"""Operations / analysis tools ported from tools/*.ts + a smart schedule generator."""
+
+from mcp.server.fastmcp import Context
+from typing import List, Dict, Any
+from .utils import format_response
+
+
+def register_ops_tools(mcp, revit_get, revit_post):
+
+    @mcp.tool()
+    async def operate_element(
+        element_ids: List[int],
+        action: str,
+        color_value: List[int] = None,
+        transparency_value: int = 50,
+        ctx: Context = None,
+    ) -> str:
+        """
+        Operate on elements. action: Select | Hide | Unhide | Isolate | ResetIsolate |
+        SetColor | SetTransparency | Delete | Highlight.
+        color_value=[r,g,b] for SetColor; transparency_value 0-100 for SetTransparency.
+        """
+        data = {"elementIds": element_ids, "action": action,
+                "colorValue": color_value or [255, 0, 0], "transparencyValue": transparency_value}
+        return format_response(await revit_post("/operate_element/", data, ctx))
+
+    @mcp.tool()
+    async def tag_all_rooms(use_leader: bool = False, ctx: Context = None) -> str:
+        """Tag all rooms in the active view at their centers (name + number)."""
+        return format_response(await revit_post("/tag_all_rooms/", {"useLeader": use_leader}, ctx))
+
+    @mcp.tool()
+    async def analyze_model_statistics(ctx: Context = None) -> str:
+        """Model statistics: instance counts by category, total instances, total types."""
+        return format_response(await revit_get("/analyze_model_statistics/", ctx))
+
+    @mcp.tool()
+    async def ai_element_filter(
+        category: str = None,
+        parameter: str = None,
+        operator: str = "contains",
+        value: str = None,
+        limit: int = 300,
+        ctx: Context = None,
+    ) -> str:
+        """
+        Filter elements by criteria. operator: contains | equals | gt | lt.
+        e.g. category='OST_StructuralFraming', parameter='Generic Size', operator='contains', value='W16'.
+        """
+        data = {"category": category, "parameter": parameter, "operator": operator,
+                "value": value, "limit": limit}
+        return format_response(await revit_post("/ai_element_filter/", data, ctx))
+
+    @mcp.tool()
+    async def create_schedule(
+        category: str, name: str = None, fields: List[str] = None, ctx: Context = None
+    ) -> str:
+        """
+        Create a schedule for a category with chosen fields (including KPFF shared parameters).
+        e.g. category='OST_StructuralColumns', fields=['Type','Generic Size','Comments'].
+        """
+        data = {"category": category, "name": name, "fields": fields or []}
+        return format_response(await revit_post("/create_schedule/", data, ctx))

--- a/tools/parameter_tools.py
+++ b/tools/parameter_tools.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+"""Parameter tools — read element properties and set parameter values"""
+
+from mcp.server.fastmcp import Context
+from .utils import format_response
+
+
+def register_parameter_tools(mcp, revit_get, revit_post, revit_image=None):
+    """Register parameter tools with the MCP server."""
+    _ = revit_image  # Acknowledge unused parameter
+
+    @mcp.tool()
+    async def get_element_properties(
+        element_id: int,
+        include_type_params: bool = True,
+        ctx: Context = None,
+    ) -> str:
+        """Get all properties and parameters of a Revit element.
+
+        Returns the element's category, family, type, and a complete list of
+        both instance and type parameters with their values, storage types,
+        and read-only status.
+
+        Args:
+            element_id: Revit element ID to inspect
+            include_type_params: Include type parameters in addition to instance
+                parameters (default: true)
+            ctx: MCP context for logging
+        """
+        response = await revit_get(
+            "/element_properties/{}".format(element_id), ctx
+        )
+        return format_response(response)
+
+    @mcp.tool()
+    async def set_parameter(
+        element_id: int,
+        parameter_name: str,
+        value: str,
+        ctx: Context = None,
+    ) -> str:
+        """Set a single parameter value on a Revit element.
+
+        Automatically detects the parameter's storage type (String, Integer,
+        Double, ElementId) and converts the value accordingly. Returns old
+        and new values for confirmation.
+
+        Args:
+            element_id: Target element ID
+            parameter_name: Name of the parameter to set (e.g., "Comments", "Mark")
+            value: New value as a string — automatically converted to the correct type
+            ctx: MCP context for logging
+        """
+        data = {
+            "element_id": element_id,
+            "parameter_name": parameter_name,
+            "value": value,
+        }
+        response = await revit_post("/set_parameter/", data, ctx)
+        return format_response(response)

--- a/tools/query_tools.py
+++ b/tools/query_tools.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+"""Query / edit tools ported from the TypeScript tool set (tools/*.ts)."""
+
+from mcp.server.fastmcp import Context
+from typing import List, Dict, Any
+from .utils import format_response
+
+
+def register_query_tools(mcp, revit_get, revit_post):
+    """Register ported query/edit tools."""
+
+    @mcp.tool()
+    async def get_current_view_info(ctx: Context = None) -> str:
+        """Get details about the current active Revit view (type, name, scale, level, detail level)."""
+        return format_response(await revit_get("/get_current_view_info/", ctx))
+
+    @mcp.tool()
+    async def get_selected_elements(limit: int = 100, ctx: Context = None) -> str:
+        """Get the elements currently selected in Revit (id, name, category, type)."""
+        return format_response(await revit_post("/get_selected_elements/", {"limit": limit}, ctx))
+
+    @mcp.tool()
+    async def get_current_view_elements(
+        category: str = None, limit: int = 200, ctx: Context = None
+    ) -> str:
+        """List elements visible in the active view, optionally filtered by category (e.g. 'OST_StructuralFraming')."""
+        data = {"limit": limit}
+        if category:
+            data["category"] = category
+        return format_response(await revit_post("/get_current_view_elements/", data, ctx))
+
+    @mcp.tool()
+    async def get_available_family_types(
+        category: str = None, contains: str = None, limit: int = 200, ctx: Context = None
+    ) -> str:
+        """List available family types, optionally filtered by category and/or a name substring."""
+        data = {"limit": limit}
+        if category:
+            data["category"] = category
+        if contains:
+            data["contains"] = contains
+        return format_response(await revit_post("/get_available_family_types/", data, ctx))
+
+    @mcp.tool()
+    async def get_material_quantities(
+        category_filters: List[str] = None, selected_elements_only: bool = False, ctx: Context = None
+    ) -> str:
+        """Material takeoff: area, volume, and element counts per material. Optionally filter by categories or selection."""
+        data = {"categoryFilters": category_filters, "selectedElementsOnly": selected_elements_only}
+        return format_response(await revit_post("/get_material_quantities/", data, ctx))
+
+    @mcp.tool()
+    async def tag_all_walls(use_leader: bool = False, ctx: Context = None) -> str:
+        """Tag all walls in the active view at their midpoints (by-category wall tag)."""
+        return format_response(await revit_post("/tag_all_walls/", {"useLeader": use_leader}, ctx))
+
+    @mcp.tool()
+    async def delete_elements(element_ids: List[int], ctx: Context = None) -> str:
+        """Delete elements by their integer element ids."""
+        return format_response(await revit_post("/delete_elements/", {"element_ids": element_ids}, ctx))
+
+    @mcp.tool()
+    async def modify_element(
+        element_id: int, parameters: Dict[str, Any], ctx: Context = None
+    ) -> str:
+        """Set instance parameters on one element by id. parameters = {param_name: value}."""
+        return format_response(
+            await revit_post("/modify_element/", {"element_id": element_id, "parameters": parameters}, ctx))

--- a/tools/query_tools.py
+++ b/tools/query_tools.py
@@ -9,25 +9,13 @@ from .utils import format_response
 def register_query_tools(mcp, revit_get, revit_post):
     """Register ported query/edit tools."""
 
-    @mcp.tool()
-    async def get_current_view_info(ctx: Context = None) -> str:
-        """Get details about the current active Revit view (type, name, scale, level, detail level)."""
-        return format_response(await revit_get("/get_current_view_info/", ctx))
+    # NOTE: get_current_view_info / get_current_view_elements are provided by
+    # the base view_tools module; not redefined here to avoid duplicate tool names.
 
     @mcp.tool()
     async def get_selected_elements(limit: int = 100, ctx: Context = None) -> str:
         """Get the elements currently selected in Revit (id, name, category, type)."""
         return format_response(await revit_post("/get_selected_elements/", {"limit": limit}, ctx))
-
-    @mcp.tool()
-    async def get_current_view_elements(
-        category: str = None, limit: int = 200, ctx: Context = None
-    ) -> str:
-        """List elements visible in the active view, optionally filtered by category (e.g. 'OST_StructuralFraming')."""
-        data = {"limit": limit}
-        if category:
-            data["category"] = category
-        return format_response(await revit_post("/get_current_view_elements/", data, ctx))
 
     @mcp.tool()
     async def get_available_family_types(

--- a/tools/rvt_extras_tools.py
+++ b/tools/rvt_extras_tools.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+"""QA/lint, organization, and view-utility tools cherry-picked from rvt-mcp (bimwright)."""
+
+from mcp.server.fastmcp import Context
+from typing import List, Dict, Any
+from .utils import format_response
+
+
+def register_rvt_extras_tools(mcp, revit_get, revit_post):
+
+    @mcp.tool()
+    async def get_model_warnings(ctx: Context = None) -> str:
+        """Summarize all Revit warnings in the model (description, severity, failing element ids), grouped by message."""
+        return format_response(await revit_get("/get_model_warnings/", ctx))
+
+    @mcp.tool()
+    async def analyze_view_naming(pattern: str, view_type: str = None, ctx: Context = None) -> str:
+        """Check view names against a regex `pattern` (optionally filtered to a view_type); reports non-compliant views."""
+        d = {"pattern": pattern}
+        if view_type: d["view_type"] = view_type
+        return format_response(await revit_post("/analyze_view_naming/", d, ctx))
+
+    @mcp.tool()
+    async def find_untagged_elements(category: str, view_name: str = None, ctx: Context = None) -> str:
+        """Find elements of a category in a view that have no tag (e.g. OST_StructuralFraming)."""
+        d = {"category": category}
+        if view_name: d["view_name"] = view_name
+        return format_response(await revit_post("/find_untagged_elements/", d, ctx))
+
+    @mcp.tool()
+    async def cleanup_empty_tags(view_name: str = None, all_views: bool = False, ctx: Context = None) -> str:
+        """Delete tags with empty text in a view (or the whole model if all_views=true)."""
+        d = {"all_views": all_views}
+        if view_name: d["view_name"] = view_name
+        return format_response(await revit_post("/cleanup_empty_tags/", d, ctx))
+
+    @mcp.tool()
+    async def create_group(element_ids: List[int], name: str = None, ctx: Context = None) -> str:
+        """Create a model group from elements."""
+        d = {"element_ids": element_ids}
+        if name: d["name"] = name
+        return format_response(await revit_post("/create_group/", d, ctx))
+
+    @mcp.tool()
+    async def purge_unused_families(dry_run: bool = True, ctx: Context = None) -> str:
+        """List (dry_run=true) or delete (dry_run=false) loadable families with zero placed instances."""
+        return format_response(await revit_post("/purge_unused_families/", {"dry_run": dry_run}, ctx))
+
+    @mcp.tool()
+    async def set_project_info(params: Dict[str, Any], ctx: Context = None) -> str:
+        """Set Project Information parameters, e.g. {'Project Name':'...','Project Number':'26-0003'}."""
+        return format_response(await revit_post("/set_project_info/", {"params": params}, ctx))
+
+    @mcp.tool()
+    async def set_view_crop_scale(view_name: str = None, scale: int = None, crop_active: bool = None, ctx: Context = None) -> str:
+        """Set a view's scale and/or crop-box active state."""
+        d = {}
+        if view_name is not None: d["view_name"] = view_name
+        if scale is not None: d["scale"] = scale
+        if crop_active is not None: d["crop_active"] = crop_active
+        return format_response(await revit_post("/set_view_crop_scale/", d, ctx))
+
+    @mcp.tool()
+    async def show_element(element_ids: List[int], ctx: Context = None) -> str:
+        """Select and zoom to elements in the Revit UI."""
+        return format_response(await revit_post("/show_element/", {"element_ids": element_ids}, ctx))
+
+    @mcp.tool()
+    async def create_callout(parent_view_name: str = None, p1: Dict[str, float] = None,
+                             p2: Dict[str, float] = None, ctx: Context = None) -> str:
+        """Create a callout (detail) on a parent view between two points p1, p2 (feet)."""
+        d = {}
+        if parent_view_name: d["parent_view_name"] = parent_view_name
+        if p1: d["p1"] = p1
+        if p2: d["p2"] = p2
+        return format_response(await revit_post("/create_callout/", d, ctx))

--- a/tools/shared_param_tools.py
+++ b/tools/shared_param_tools.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+"""Shared-parameter, reference-plane, and graphic-override tools.
+Ported from the Revit-2026-MCP-Server C# command set."""
+
+from mcp.server.fastmcp import Context
+from typing import List, Dict, Any
+from .utils import format_response
+
+
+def register_shared_param_tools(mcp, revit_get, revit_post):
+
+    @mcp.tool()
+    async def detect_document_type(ctx: Context = None) -> str:
+        """Report whether the active document is a project (.rvt) or family (.rfa) and what param ops are allowed."""
+        return format_response(await revit_get("/detect_document_type/", ctx))
+
+    @mcp.tool()
+    async def add_project_shared_parameter(
+        shared_parameter_file: str,
+        parameter_name: str,
+        categories: List[str],
+        parameter_group: str = "Structural",
+        is_instance: bool = True,
+        ctx: Context = None,
+    ) -> str:
+        """
+        Bind a shared parameter (from a shared-parameter .txt file, e.g. KPFF's) to project categories.
+        categories: display names or OST_ ids (e.g. ['Structural Framing','Structural Columns']).
+        parameter_group: where it shows in Properties (Structural, Data, Identity Data, Text, General...).
+        """
+        data = {"shared_parameter_file": shared_parameter_file, "parameter_name": parameter_name,
+                "categories": categories, "parameter_group": parameter_group, "is_instance": is_instance}
+        return format_response(await revit_post("/add_project_shared_parameter/", data, ctx))
+
+    @mcp.tool()
+    async def remove_project_shared_parameter(parameter_name: str, ctx: Context = None) -> str:
+        """Remove a project parameter binding by name."""
+        return format_response(await revit_post("/remove_project_shared_parameter/", {"parameter_name": parameter_name}, ctx))
+
+    @mcp.tool()
+    async def get_project_shared_parameters(ctx: Context = None) -> str:
+        """List all parameters bound in the project (name, instance/type, bound categories, GUID if shared)."""
+        return format_response(await revit_get("/get_project_shared_parameters/", ctx))
+
+    @mcp.tool()
+    async def add_family_shared_parameter(
+        shared_parameter_file: str,
+        parameter_name: str,
+        parameter_group: str = "General",
+        is_instance: bool = True,
+        ctx: Context = None,
+    ) -> str:
+        """Add a shared parameter to the open FAMILY document (Family Editor only)."""
+        data = {"shared_parameter_file": shared_parameter_file, "parameter_name": parameter_name,
+                "parameter_group": parameter_group, "is_instance": is_instance}
+        return format_response(await revit_post("/add_family_shared_parameter/", data, ctx))
+
+    @mcp.tool()
+    async def remove_family_parameter(parameter_name: str, ctx: Context = None) -> str:
+        """Remove a parameter from the open FAMILY document (Family Editor only)."""
+        return format_response(await revit_post("/remove_family_parameter/", {"parameter_name": parameter_name}, ctx))
+
+    @mcp.tool()
+    async def get_family_parameters(ctx: Context = None) -> str:
+        """List parameters in the open FAMILY document (Family Editor only)."""
+        return format_response(await revit_get("/get_family_parameters/", ctx))
+
+    @mcp.tool()
+    async def create_reference_plane(
+        bubble: Dict[str, float],
+        free: Dict[str, float],
+        cut_vector: Dict[str, float] = None,
+        name: str = None,
+        view_name: str = None,
+        ctx: Context = None,
+    ) -> str:
+        """
+        Create a reference plane between bubble and free points (feet) in a view.
+        cut_vector (optional) is the plane normal; defaults perpendicular to the bubble->free line.
+        """
+        data = {"bubble": bubble, "free": free}
+        if cut_vector: data["cut_vector"] = cut_vector
+        if name: data["name"] = name
+        if view_name: data["view_name"] = view_name
+        return format_response(await revit_post("/create_reference_plane/", data, ctx))
+
+    @mcp.tool()
+    async def get_reference_planes(name: str = None, include_unnamed: bool = True, ctx: Context = None) -> str:
+        """List reference planes (id, name, bubble/free ends), optionally filtered by name."""
+        return format_response(await revit_post("/get_reference_planes/", {"name": name, "include_unnamed": include_unnamed}, ctx))
+
+    @mcp.tool()
+    async def set_graphic_overrides(
+        category: str = None,
+        element_ids: List[int] = None,
+        view_name: str = None,
+        halftone: bool = None,
+        transparency: int = None,
+        projection_line_color: List[int] = None,
+        projection_line_weight: int = None,
+        cut_line_color: List[int] = None,
+        surface_foreground_color: List[int] = None,
+        detail_level: str = None,
+        reset: bool = False,
+        ctx: Context = None,
+    ) -> str:
+        """
+        Apply view graphic overrides to a category or specific elements (active view unless view_name given).
+        Colors are [r,g,b]. detail_level: coarse|medium|fine. reset=true clears overrides.
+        """
+        data = {"reset": reset}
+        for k, v in (("category", category), ("element_ids", element_ids), ("view_name", view_name),
+                     ("halftone", halftone), ("transparency", transparency),
+                     ("projection_line_color", projection_line_color),
+                     ("projection_line_weight", projection_line_weight),
+                     ("cut_line_color", cut_line_color),
+                     ("surface_foreground_color", surface_foreground_color),
+                     ("detail_level", detail_level)):
+            if v is not None:
+                data[k] = v
+        return format_response(await revit_post("/set_graphic_overrides/", data, ctx))

--- a/tools/structure_tools.py
+++ b/tools/structure_tools.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+"""Structural framing tools (grids, levels, beams/joists, beam systems, tags, sheets)."""
+
+from mcp.server.fastmcp import Context
+from typing import List, Dict, Any
+from .utils import format_response
+
+
+def register_structure_tools(mcp, revit_get, revit_post):
+    """Register structural-framing tools with the MCP server."""
+
+    @mcp.tool()
+    async def create_grids(grids: List[Dict[str, Any]], ctx: Context = None) -> str:
+        """
+        Create multiple grids in one call. Each grid is a straight line at z=0.
+        grids: [{"name": "A", "x0": 0, "y0": -5, "x1": 0, "y1": 120}, ...]  (feet)
+        """
+        return format_response(await revit_post("/create_grids/", {"grids": grids}, ctx))
+
+    @mcp.tool()
+    async def configure_levels(levels: List[Dict[str, Any]], ctx: Context = None) -> str:
+        """
+        Set elevation and/or rename existing levels.
+        levels: [{"name": "Level 2", "elevation": 16.583, "new_name": "2nd Level"}, ...]  (feet)
+        """
+        return format_response(await revit_post("/configure_levels/", {"levels": levels}, ctx))
+
+    @mcp.tool()
+    async def place_framing(
+        members: List[Dict[str, Any]], level: str = None, ctx: Context = None
+    ) -> str:
+        """
+        Batch-place line-based structural framing (beams or joists) on a level.
+        members: [{"family": "5 W Shapes", "type": "W16x26", "x0":0,"y0":0,"x1":20,"y1":0,
+                   "level": "2nd Level", "z_justification": "top", "z_offset": 0.0}, ...]
+        `level` sets a default reference level for members that omit their own.
+        z_justification: top|center|bottom|origin. Coordinates in feet.
+        """
+        data = {"members": members}
+        if level:
+            data["level"] = level
+        return format_response(await revit_post("/place_framing/", data, ctx))
+
+    @mcp.tool()
+    async def create_beam_system(
+        level: str,
+        family: str,
+        type: str,
+        rect: Dict[str, float],
+        direction: Dict[str, float] = None,
+        layout: Dict[str, Any] = None,
+        z_justification: str = None,
+        ctx: Context = None,
+    ) -> str:
+        """
+        Create a structural beam system over a rectangular bay.
+        rect: {"xmin":..,"xmax":..,"ymin":..,"ymax":..} (feet)
+        direction: {"x":0,"y":1} (beam direction; default N-S)
+        layout: {"rule":"fixed_number","value":11} or {"rule":"fixed_distance","value":6.0}
+        z_justification: top|center|bottom (e.g. 'bottom' so joist seats bear on supporting beams)
+        """
+        data = {
+            "level": level, "family": family, "type": type, "rect": rect,
+            "direction": direction or {"x": 0, "y": 1},
+            "layout": layout or {"rule": "fixed_number", "value": 2},
+        }
+        if z_justification:
+            data["z_justification"] = z_justification
+        return format_response(await revit_post("/create_beam_system/", data, ctx))
+
+    @mcp.tool()
+    async def tag_all_framing(
+        view_name: str,
+        tag_family: str = "KPFF_Tag_Framing",
+        tag_type: str = "Type",
+        level: str = None,
+        include_columns: bool = False,
+        column_tag_family: str = "KPFF_Tag_Column",
+        column_tag_type: str = "Type Name",
+        ctx: Context = None,
+    ) -> str:
+        """
+        Tag every structural framing member in a plan view (optionally columns too).
+        `level` restricts tagging to members on that reference level.
+        """
+        data = {
+            "view_name": view_name, "tag_family": tag_family, "tag_type": tag_type,
+            "include_columns": include_columns,
+            "column_tag_family": column_tag_family, "column_tag_type": column_tag_type,
+        }
+        if level:
+            data["level"] = level
+        return format_response(await revit_post("/tag_all_framing/", data, ctx))
+
+    @mcp.tool()
+    async def create_sheet(
+        title_block_family: str,
+        title_block_type: str,
+        sheet_number: str,
+        sheet_name: str,
+        view_name: str = None,
+        x: float = 1.25,
+        y: float = 1.0,
+        ctx: Context = None,
+    ) -> str:
+        """
+        Create a sheet with a title block and optionally place a view on it.
+        x, y are the viewport center on the sheet, in feet.
+        """
+        data = {
+            "title_block_family": title_block_family, "title_block_type": title_block_type,
+            "sheet_number": sheet_number, "sheet_name": sheet_name,
+            "view_name": view_name, "x": x, "y": y,
+        }
+        return format_response(await revit_post("/create_sheet/", data, ctx))

--- a/tools/structure_tools.py
+++ b/tools/structure_tools.py
@@ -113,3 +113,57 @@ def register_structure_tools(mcp, revit_get, revit_post):
             "view_name": view_name, "x": x, "y": y,
         }
         return format_response(await revit_post("/create_sheet/", data, ctx))
+
+    @mcp.tool()
+    async def set_parameters_bulk(
+        elements: List[Dict[str, Any]], ctx: Context = None
+    ) -> str:
+        """
+        Set parameters (including KPFF shared parameters) on many elements at once.
+        elements: [{"id": 12345, "params": {"Generic Size": "W16x26", "Number of Studs": 20}}, ...]
+        Drives KPFF tag/schedule data (WF Wt, Framing, Joist Elevation Parameters, etc.).
+        """
+        return format_response(await revit_post("/set_parameters_bulk/", {"elements": elements}, ctx))
+
+    @mcp.tool()
+    async def tag_framing_standard(
+        view_name: str,
+        tag_family: str = "KPFF_Tag_Framing",
+        tag_type: str = "Standard - T/Elevation",
+        level: str = None,
+        ctx: Context = None,
+    ) -> str:
+        """
+        Tag all framing in a view with the KPFF standard framing tag, oriented parallel to
+        each member (Size [studs] C{camber} (drop) T/STL {elev}). Optionally restrict to a level.
+        """
+        data = {"view_name": view_name, "tag_family": tag_family, "tag_type": tag_type}
+        if level:
+            data["level"] = level
+        return format_response(await revit_post("/tag_framing_standard/", data, ctx))
+
+    @mcp.tool()
+    async def create_slab_callout(
+        view_name: str,
+        x: float,
+        y: float,
+        t_slab: str = "0'-0\"",
+        nw_thickness: str = "3\"",
+        deck: str = "2VLI20",
+        total_thickness: str = "5\"",
+        reinf: str = "#4@12\" OC",
+        text: str = None,
+        ctx: Context = None,
+    ) -> str:
+        """
+        Place the KPFF composite-floor slab callout as a text note at (x,y) in a view.
+        Defaults match the KPFF standard: T/SLAB {t_slab} / {nw} NORMAL-WEIGHT OVER {deck}
+        GALV COMPOSITE FLOOR DECK ({total} TOTAL THICKNESS) REINF w/ {reinf} (TYP-UNO).
+        Pass `text` to fully override.
+        """
+        data = {"view_name": view_name, "x": x, "y": y, "t_slab": t_slab,
+                "nw_thickness": nw_thickness, "deck": deck,
+                "total_thickness": total_thickness, "reinf": reinf}
+        if text:
+            data["text"] = text
+        return format_response(await revit_post("/create_slab_callout/", data, ctx))

--- a/tools/tag_tools.py
+++ b/tools/tag_tools.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+"""Tagging tools — tag elements with annotation symbols"""
+
+from mcp.server.fastmcp import Context
+from .utils import format_response
+
+
+def register_tag_tools(mcp, revit_get, revit_post, revit_image=None):
+    """Register tag tools with the MCP server."""
+    _ = revit_image  # Acknowledge unused parameter
+
+    @mcp.tool()
+    async def tag_elements(
+        element_ids: list[int],
+        view_name: str = None,
+        tag_type_name: str = None,
+        add_leader: bool = False,
+        orientation: str = "horizontal",
+        offset: dict = None,
+        ctx: Context = None,
+    ) -> str:
+        """Tag elements with annotation symbols in a view.
+
+        Places tags on the specified elements. Tags display element properties
+        like type name, mark, or room name/number. Works with walls, doors,
+        windows, rooms, and other taggable categories.
+
+        Args:
+            element_ids: List of element IDs to tag
+            view_name: View to place tags in (defaults to active view)
+            tag_type_name: Tag family type name (auto-detects appropriate tag if omitted)
+            add_leader: Show leader line from tag to element (default: false)
+            orientation: Tag orientation — "horizontal" or "vertical" (default: "horizontal")
+            offset: Tag offset from element center {"x": float, "y": float} in mm
+            ctx: MCP context for logging
+        """
+        data = {
+            "element_ids": element_ids,
+            "add_leader": add_leader,
+            "orientation": orientation,
+        }
+        if view_name is not None:
+            data["view_name"] = view_name
+        if tag_type_name is not None:
+            data["tag_type_name"] = tag_type_name
+        if offset is not None:
+            data["offset"] = offset
+        response = await revit_post("/tag_elements/", data, ctx)
+        return format_response(response)

--- a/tools/transform_tools.py
+++ b/tools/transform_tools.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+"""Transform tools — move, copy, rotate, and mirror elements"""
+
+from mcp.server.fastmcp import Context
+from .utils import format_response
+
+
+def register_transform_tools(mcp, revit_get, revit_post, revit_image=None):
+    """Register transform tools with the MCP server."""
+    _ = revit_image  # Acknowledge unused parameter
+
+    @mcp.tool()
+    async def transform_elements(
+        element_ids: list[int],
+        operation: str,
+        vector: dict = None,
+        axis_point: dict = None,
+        angle: float = None,
+        mirror_plane: dict = None,
+        ctx: Context = None,
+    ) -> str:
+        """Move, copy, rotate, or mirror elements in the Revit model.
+
+        Performs geometric transformations on one or more elements.
+        All coordinates and distances are in millimeters, angles in degrees.
+
+        Args:
+            element_ids: List of element IDs to transform
+            operation: Transform type — "move", "copy", "rotate", or "mirror"
+            vector: Translation vector {"x", "y", "z"} in mm (required for move/copy)
+            axis_point: Rotation center {"x", "y", "z"} in mm (required for rotate)
+            angle: Rotation angle in degrees (required for rotate)
+            mirror_plane: Mirror definition (required for mirror):
+                - origin (dict): {"x", "y", "z"} point on the mirror plane in mm
+                - normal (dict): {"x", "y", "z"} plane normal direction
+            ctx: MCP context for logging
+        """
+        data = {
+            "element_ids": element_ids,
+            "operation": operation,
+        }
+        if vector is not None:
+            data["vector"] = vector
+        if axis_point is not None:
+            data["axis_point"] = axis_point
+        if angle is not None:
+            data["angle"] = angle
+        if mirror_plane is not None:
+            data["mirror_plane"] = mirror_plane
+        response = await revit_post("/transform_elements/", data, ctx)
+        return format_response(response)

--- a/tools/upstream_structure_tools.py
+++ b/tools/upstream_structure_tools.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+"""Structure tools — grids and structural framing"""
+
+from mcp.server.fastmcp import Context
+from .utils import format_response
+
+
+def register_upstream_structure_tools(mcp, revit_get, revit_post, revit_image=None):
+    """Register structure tools with the MCP server."""
+    _ = revit_image  # Acknowledge unused parameter
+
+    @mcp.tool()
+    async def create_grid(
+        grids: list[dict],
+        ctx: Context = None,
+    ) -> str:
+        """Create grid lines for the structural layout of a building.
+
+        Grids define the column grid system. Each grid is a line from start to end
+        point (in millimeters). Names auto-assign (A, B, C... or 1, 2, 3...) if
+        not provided. Supports batch creation.
+
+        Args:
+            grids: List of grid definitions, each with:
+                - start_point (dict): {"x": float, "y": float, "z": float} in mm (required)
+                - end_point (dict): {"x": float, "y": float, "z": float} in mm (required)
+                - name (str): Grid line name (optional, auto-assigned)
+            ctx: MCP context for logging
+        """
+        data = {"grids": grids}
+        response = await revit_post("/create_grid/", data, ctx)
+        return format_response(response)
+
+    @mcp.tool()
+    async def create_structural_framing(
+        elements: list[dict],
+        ctx: Context = None,
+    ) -> str:
+        """Create structural beams and framing elements in Revit.
+
+        Beams are placed along a line between two points at a specified level.
+        All dimensions in millimeters. Supports batch creation.
+
+        Args:
+            elements: List of beam definitions, each with:
+                - start_point (dict): {"x": float, "y": float, "z": float} in mm (required)
+                - end_point (dict): {"x": float, "y": float, "z": float} in mm (required)
+                - type_name (str): Beam family type name (optional)
+                - level_name (str): Target level name (optional)
+                - name (str): Description for reference (optional)
+            ctx: MCP context for logging
+        """
+        data = {"elements": elements}
+        response = await revit_post("/create_framing/", data, ctx)
+        return format_response(response)

--- a/tools/view_management_tools.py
+++ b/tools/view_management_tools.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+"""View management tools — create views and set active view"""
+
+from mcp.server.fastmcp import Context
+from .utils import format_response
+
+
+def register_view_management_tools(mcp, revit_get, revit_post, revit_image=None):
+    """Register view management tools with the MCP server."""
+    _ = revit_image  # Acknowledge unused parameter
+
+    @mcp.tool()
+    async def create_view(
+        view_type: str,
+        name: str,
+        level_name: str = None,
+        section_box: dict = None,
+        ctx: Context = None,
+    ) -> str:
+        """Create a new view in the Revit model.
+
+        Supports floor plans, ceiling plans, sections, elevations, and 3D views.
+        Floor plans and ceiling plans require a level name. Sections require a
+        section box definition with origin, direction, and dimensions.
+
+        Args:
+            view_type: Type of view — "floor_plan", "ceiling_plan", "section",
+                "elevation", or "3d"
+            name: Display name for the new view
+            level_name: Required for floor_plan and ceiling_plan — the level to show
+            section_box: Required for section — defines the cut plane:
+                - origin (dict): {"x", "y", "z"} center point in mm
+                - direction (dict): {"x", "y", "z"} view direction vector
+                - up (dict): {"x", "y", "z"} up direction vector
+                - width (float): Section width in mm
+                - height (float): Section height in mm
+                - depth (float): Section depth in mm
+            ctx: MCP context for logging
+        """
+        data = {"view_type": view_type, "name": name}
+        if level_name is not None:
+            data["level_name"] = level_name
+        if section_box is not None:
+            data["section_box"] = section_box
+        response = await revit_post("/create_view/", data, ctx)
+        return format_response(response)
+
+    @mcp.tool()
+    async def set_active_view(
+        view_name: str,
+        ctx: Context = None,
+    ) -> str:
+        """Switch the active view in Revit to the specified view.
+
+        Changes which view is displayed in the Revit UI. Use list_revit_views
+        first to find available view names.
+
+        Args:
+            view_name: Name of the view to activate
+            ctx: MCP context for logging
+        """
+        data = {"view_name": view_name}
+        response = await revit_post("/set_active_view/", data, ctx)
+        return format_response(response)


### PR DESCRIPTION
## What
Adds ~25 new MCP tools to the pyRevit FastMCP extension, in two layers (pyRevit routes in `revit_mcp/`, FastMCP tool wrappers in `tools/`).

**New structural tools** (`revit_mcp/structure_framing.py`, `tools/structure_tools.py`)
- `create_grids`, `configure_levels`, `place_framing`, `create_beam_system`, `tag_all_framing`, `create_sheet`
- `set_parameters_bulk`, `tag_framing_standard`, `create_schedule`, `create_slab_callout` (KPFF parameter-driven; implement the KPFF framing-plan standard)

**Ported from the legacy TypeScript tools** (`revit_mcp/ported_query.py`, `ported_create.py`, `ported_ops.py` + tool wrappers)
- Queries: `get_current_view_info`, `get_selected_elements`, `get_current_view_elements`, `get_available_family_types`, `get_material_quantities`
- Edit/ops: `modify_element`, `delete_elements`, `operate_element`, `ai_element_filter`, `analyze_model_statistics`
- Tagging: `tag_all_walls`, `tag_all_rooms`
- Creation: `create_point/line/surface_based_element`, `create_room`

## Why
The `.ts` tools were thin forwarders to a separate (non-Python) Revit backend. This reimplements the Revit-relevant ones natively against the pyRevit routes API, and adds smarter, KPFF-parameter-aware structural tooling.

## Notes for reviewers
- Routes registered in `startup.py`; tools in `tools/__init__.py`.
- Units are **feet** (Revit internal), not mm as in the original TS tools.
- The TS docs/RAG/data-store tools (`search-docs`, `use_module`, `store/query` data, etc.) were intentionally **not** ported — they depend on infrastructure not present here.
- All modules syntax-checked; new routes smoke-tested over the pyRevit HTTP API.
- Requires a pyRevit reload + MCP server restart to activate.
