### PR TITLE
Fix Revit hard crash: run status/model_info in API context

### DIFF
--- a/revit_mcp/model_info.py
+++ b/revit_mcp/model_info.py
@@ -18,7 +18,7 @@ def register_model_info_routes(api):
     """Register all model information routes with the API"""
 
     @api.route("/model_info/", methods=["GET"])
-    def get_model_info():
+    def get_model_info(doc):
         """
         Get comprehensive information about the current Revit model
 
@@ -31,7 +31,6 @@ def register_model_info_routes(api):
         - Link status
         """
         try:
-            doc = revit.doc
             if not doc:
                 return routes.make_response(
                     data={"error": "No active Revit document"}, status=503

--- a/revit_mcp/status.py
+++ b/revit_mcp/status.py
@@ -13,17 +13,14 @@ def register_status_routes(api):
     """Register all status-related routes with the API"""
     
     @api.route('/status/', methods=["GET"])
-    def revit_status():
+    def revit_status(doc):
         """
         Health check endpoint that verifies Revit context availability
-        
+
         Returns:
             dict: Health status with Revit document information
         """
         try:
-            from pyrevit import revit
-            
-            doc = revit.doc
             if doc:
                 return routes.make_response(data={
                     "status": "active",


### PR DESCRIPTION
pyRevit's routes dispatcher decides whether to marshal a handler onto the Revit API context by inspecting its signature for uiapp/uidoc/doc (routes/server/handler.py, wants_api_context). revit_status() and get_model_info() declared no parameters, so they ran on the HTTP server's background thread and reached for revit.doc there.

That access raises, the except branch calls logger.error, and pyRevit's ScriptIO lazily constructs its WPF output window from that non-STA thread. The resulting InvalidOperationException is unhandled off the main thread and terminates the Revit process (0xe0434352).

Declaring doc restores API-context dispatch. Verified on Revit 2027.2 (.NET 10) with pyRevit 6.5.4: /status/ returns 503 with no document and 200 with one, /model_info/ returns model data, Revit survives both.

Upstream issue #47.