### PR TITLE
Use 127.0.0.1 instead of localhost for Revit routes base URL

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ mcp = FastMCP(
 )
 
 # Configuration
-REVIT_HOST = "localhost"
+REVIT_HOST = "127.0.0.1"
 REVIT_PORT = 48884  # Default pyRevit Routes port
 BASE_URL = f"http://{REVIT_HOST}:{REVIT_PORT}/revit_mcp"
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -4,7 +4,7 @@ import os
 import pytest
 import httpx
 
-BASE_URL = "http://localhost:48884/revit_mcp"
+BASE_URL = "http://127.0.0.1:48884/revit_mcp"
 TEST_FILE = os.path.join(os.path.dirname(os.path.dirname(__file__)), "test.rvt")
 
 


### PR DESCRIPTION
## What changed

Switched the pyRevit Routes base URL from `localhost` to `127.0.0.1` in:
- `main.py` (`REVIT_HOST` used to build `BASE_URL`)
- `tests/integration/conftest.py` (`BASE_URL` used by the integration test fixtures)

## Why

Avoids depending on `localhost` DNS/hosts-file resolution when connecting to the local pyRevit Routes endpoint (`http://<host>:48884/revit_mcp`). Using the literal loopback address `127.0.0.1` sidesteps any environment where `localhost` resolution is slow, misconfigured, or resolves to IPv6 (`::1`) first, which can cause unnecessary connection delays or failures against a server bound to `127.0.0.1`.

## Notes for reviewers

- Purely a configuration/constant change, no behavioral/logic change beyond which loopback form is used to reach the same local server.
- Both the runtime server config (`main.py`) and the integration test fixtures (`conftest.py`) are updated together so they stay consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)